### PR TITLE
More tray icon improvements

### DIFF
--- a/RadialActions/App.xaml.cs
+++ b/RadialActions/App.xaml.cs
@@ -91,15 +91,13 @@ public partial class App : Application
         var window = Current.Windows.OfType<T>().FirstOrDefault() ?? new T();
         window.Owner = owner;
 
-        // Restore an existing window.
-        if (window.IsVisible)
+        window.Show();
+
+        if (window.WindowState == WindowState.Minimized)
         {
             SystemCommands.RestoreWindow(window);
-            window.Activate();
-            return;
         }
 
-        // Show the new window.
-        window.Show();
+        window.Activate();
     }
 }

--- a/RadialActions/MainWindow.xaml
+++ b/RadialActions/MainWindow.xaml
@@ -89,7 +89,7 @@
                         IconSource="RadialActions.ico" MenuActivation="RightClick"
                         TrayBalloonTipClicked="OnTrayBalloonTipClicked"
                         TrayLeftMouseDoubleClick="OnTrayLeftMouseDoubleClick"
-                        TrayLeftMouseDown="OnTrayLeftMouseDown" />
+                        TrayLeftMouseClick="OnTrayLeftMouseDown" />
     </Window.Resources>
 
     <local:PieControl x:Name="PieMenu"

--- a/RadialActions/MainWindow.xaml
+++ b/RadialActions/MainWindow.xaml
@@ -86,6 +86,7 @@
         </ContextMenu>
 
         <tb:TaskbarIcon x:Key="TrayIcon" x:Shared="False"
+                        ToolTipText="Radial Actions"
                         IconSource="RadialActions.ico" MenuActivation="RightClick"
                         TrayBalloonTipClicked="OnTrayBalloonTipClicked"
                         TrayLeftMouseDoubleClick="OnTrayLeftMouseDoubleClick"

--- a/RadialActions/RadialActions.csproj
+++ b/RadialActions/RadialActions.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-    <PackageReference Include="H.NotifyIcon.Wpf" Version="2.4.1" />
+    <PackageReference Include="H.NotifyIcon.Wpf" Version="2.4.2-dev.17" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Serilog" Version="4.3.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/RadialActions/Services/TrayService.cs
+++ b/RadialActions/Services/TrayService.cs
@@ -16,7 +16,6 @@ internal sealed class TrayService : IDisposable
         trayContextMenu.DataContext = dataContext;
         _trayIcon.ContextMenu = trayContextMenu;
         _trayIcon.ForceCreate(enablesEfficiencyMode: false);
-        _trayIcon.ToolTipText = "Radial Actions";
         _trayIcon.ShowNotification("Radial Actions", $"Press {initialHotkey} to open the menu", sound: false);
         Log.Debug("Created tray icon");
     }

--- a/RadialActions/Services/TrayService.cs
+++ b/RadialActions/Services/TrayService.cs
@@ -25,7 +25,7 @@ internal sealed class TrayService : IDisposable
     {
         _trayIcon.ShowNotification(
             "Update available",
-            $"v{latestVersion} is available to download!",
+            $"Get v{latestVersion} from Settings",
             NotificationIcon.Info);
     }
 


### PR DESCRIPTION
- Fix Settings window not being opened into the foreground on notification click
- Tweak update available notification text
- Fix double click triggering menu as well https://github.com/HavenDV/H.NotifyIcon/pull/240
- Remove tool tip text workaround https://github.com/HavenDV/H.NotifyIcon/pull/239