### PR TITLE
Add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,92 @@
+# AGENTS.md
+
+This file is the root harness for coding agents working on Radial Actions. Keep it short, accurate, and operational. When a repeated mistake shows up, prefer adding a test, script, workflow check, or a tighter instruction here over adding broad prose.
+
+## Project Map
+
+- `RadialActions.sln` is the entry point.
+- `RadialActions/` contains the WPF desktop app targeting `net10.0-windows`.
+- `RadialActions.Tests/` contains xUnit v3 tests for deterministic behavior.
+- `.github/actions/full-build/action.yml` defines the CI build: `dotnet build`, `dotnet test`, publish x64/arm64 binaries, zip them, and build MSI installers.
+- `Package.wxs` defines the MSI packaging shape.
+- `Settings.XamlStyler` is the XAML style configuration.
+
+## Harness Principles
+
+- Treat this file as a map, not an encyclopedia. Put durable behavior in code, tests, project files, README updates, or future focused docs when the repo grows.
+- Make project knowledge repository-local. If an issue, review comment, release failure, or UI decision should guide future work, capture it in a versioned artifact.
+- Prefer enforceable invariants. If an instruction becomes important enough to repeat, look for a test, analyzer, CI step, or small helper API that can enforce it.
+- Work in small, reviewable changes. Keep unrelated cleanup out of feature and fix PRs unless it is necessary to complete the task safely.
+- Optimize for agent legibility and human maintainability: clear names, predictable file locations, narrow helpers, and deterministic tests.
+
+## Local Commands
+
+Run commands from the repository root unless noted.
+
+- Restore: `dotnet restore RadialActions.sln`
+- Build: `dotnet build RadialActions.sln`
+- Test: `dotnet test RadialActions.sln`
+- Release publish example: `dotnet publish ./RadialActions/RadialActions.csproj -o publish/x64 -c Release -f net10.0-windows --os win --arch x64 --self-contained -p:PublishSingleFile=true -p:DebugType=embedded`
+
+For documentation-only changes, explain why build or test commands were skipped. For code, project, packaging, workflow, or XAML changes, run the closest relevant command and then `dotnet test RadialActions.sln` before handing off.
+
+## Working Loop
+
+1. Start with `git status --short --branch` and inspect existing changes before editing.
+2. Turn the request into concrete acceptance criteria. Include UI behavior, persistence behavior, startup behavior, and packaging behavior when relevant.
+3. Search with `rg` before changing code so existing helpers and patterns are reused.
+4. Make the smallest coherent edit. Avoid reformatting untouched files.
+5. Add or update tests for changed deterministic behavior.
+6. Run the relevant verification commands and record exactly what passed or why a command could not be run.
+7. In PRs, describe the problem, the design choice, validation, risks, and follow-up work.
+
+## Architecture Boundaries
+
+- Keep app code in the `RadialActions` namespace unless there is a strong reason to introduce a narrower namespace.
+- `RadialActions/Data/` holds action, hotkey, conversion, and Windows interop helpers. Keep parsing and validation logic pure where possible so it can be tested without global hooks or shell execution.
+- `RadialActions/Services/` holds application services such as tray, hotkey, menu, and updates. Keep OS side effects isolated here or behind small helpers.
+- `RadialActions/Pie/` owns radial menu layout, rendering state, visual construction, and theme snapshots. Deterministic geometry belongs in `PieLayoutCalculator` or a similarly testable helper.
+- `RadialActions/Properties/Settings*.cs` owns persisted settings. When adding persisted fields, handle missing, null, or old values in normalization and cover serialization behavior in tests.
+- XAML code-behind is acceptable in this app. Keep UI event handlers thin and move reusable calculations, parsing, and state transitions into testable C# helpers.
+
+## Product Invariants
+
+- Radial Actions is a lightweight Windows utility opened by a global hotkey. Startup, hotkey registration, tray behavior, and menu display should stay fast and predictable.
+- User-configured actions must not execute during tests, settings load, preview rendering, or validation.
+- Invalid or stale settings should normalize to safe defaults instead of crashing on startup.
+- Shell actions must preserve explicit target, arguments, and working directory behavior.
+- Key actions must accept known media/volume actions and validated custom shortcuts; invalid shortcuts should fail clearly.
+- Update checks must remain controlled by settings and should not introduce surprise network work in deterministic tests.
+
+## Testing Guidance
+
+- Put tests in `RadialActions.Tests/` and follow the existing xUnit style.
+- Prefer testing pure helpers and observable state over WPF window automation.
+- Cover edge cases for hotkey parsing, settings normalization, action execution validation, and pie geometry.
+- When fixing a UI bug, first ask whether the failing behavior can be represented as deterministic state, layout math, command selection, or serialization. If yes, test that layer.
+- Do not write tests that require registering global hotkeys, launching external processes, opening URLs, or depending on the local desktop state.
+
+## WPF And UI Guidance
+
+- Preserve existing XAML names and bindings used by code-behind.
+- Use the existing theme and layout patterns before introducing new resources.
+- Keep visual changes inspectable: describe the expected before/after behavior and, when practical, manually run the app on Windows.
+- Avoid hiding failures in broad `catch` blocks. If user-facing recovery is needed, log the exception and keep the fallback narrow.
+
+## Dependencies And Packaging
+
+- Be conservative with new dependencies. Prefer the .NET/WPF platform and existing packages unless a dependency removes meaningful complexity.
+- If package versions change, verify restore, build, and tests.
+- Packaging changes should consider both `x64` and `arm64` because CI publishes both.
+- Do not change release tag behavior unless the release workflow is part of the task.
+
+## PR Expectations
+
+- Use polished branch names and PR titles that describe the work rather than the tool that produced it.
+- Include a concise summary, validation results, and any residual risk.
+- If follow-up work is recommended, explain what signal would justify it and what check or artifact should enforce it.
+- Never claim a command passed unless it was run successfully in the current branch.
+
+## Future Harness Upgrades
+
+Keep this file as the only agent instruction file for now. If the repository grows enough that this file becomes crowded, split durable knowledge into focused docs and leave this file as the table of contents. Good candidates would be architecture notes, release mechanics, UI verification, and quality gates.


### PR DESCRIPTION
## Summary

Adds a single root `AGENTS.md` as the initial harness engineering layer for Radial Actions.

The file gives coding agents a compact, repository-specific operating contract:

- Project map for the WPF app, xUnit tests, CI build action, packaging, and XAML styling config.
- Local restore/build/test/publish commands that match the repository shape.
- A working loop for turning requests into acceptance criteria, focused edits, tests, and PR notes.
- Radial Actions-specific architecture boundaries for `Data`, `Services`, `Pie`, settings, and XAML code-behind.
- Product invariants for hotkeys, action execution, settings normalization, shell actions, key actions, and update checks.
- Testing guidance that favors deterministic helpers over desktop automation or real OS side effects.
- PR expectations and a future split point if the single-file harness becomes too crowded.

## Reasoning

OpenAI's harness engineering write-up frames the engineer's role in agent-first work as designing the environment, specifying intent, and building feedback loops rather than only writing code. This PR applies that idea at the smallest useful scale for Radial Actions: one root instruction file that tells future agents how to move through the existing repository and where judgment should become tests or tooling.

The same article warns against a large monolithic instruction manual. It recommends treating `AGENTS.md` as a map rather than an encyclopedia, with durable knowledge stored in repository-local, versioned artifacts. Because Radial Actions is still small, this PR intentionally does not add a `docs/` tree or nested instruction files yet. The root file is enough to orient agents without introducing a documentation system that would need maintenance before the repo has enough surface area to justify it.

The guidance is intentionally enforceability-oriented. The OpenAI article argues that documentation alone does not preserve architecture and that repeated judgment should move into mechanical checks. The new file reflects that by telling agents to prefer tests, analyzers, workflow checks, or helper APIs when a rule becomes important enough to repeat.

The open AGENTS.md format describes the file as a predictable README-like place for agent-specific build steps, tests, conventions, security notes, and PR guidance. This PR follows that shape while keeping the content specific to Radial Actions rather than generic agent advice.

## Design Choices

1. **Single root file for now.** The user requested one `AGENTS.md`, and the repository currently has one app project, one test project, and a small CI surface. A root-only guide is simpler and less likely to drift than a premature documentation hierarchy.

2. **CI-aligned commands.** The guide names `dotnet build RadialActions.sln` and `dotnet test RadialActions.sln`, matching the full-build action's build and test flow. It also includes a release publish example because packaging is part of the repository's operational surface.

3. **Deterministic testing bias.** Radial Actions touches global hotkeys, shell execution, WPF UI, tray behavior, and update checks. The guide steers future work toward pure helpers and observable state tests so agents do not accidentally make tests depend on the local desktop, registered hotkeys, launched processes, or network state.

4. **Product invariants over style trivia.** The most important future failures would be user-impacting: executing actions unexpectedly, crashing on stale settings, breaking shell/key action semantics, slowing startup, or introducing surprise network work. Those are called out directly.

5. **Escalation path for future harness work.** The file says to split into focused docs only when crowding becomes real. That keeps the current change small while preserving a clear next step if the project grows.

## Validation

- `git diff --cached --check` passed before commit.
- `dotnet --info` confirmed the local environment has .NET SDK `10.0.103` and the Windows Desktop runtime installed.
- `dotnet test RadialActions.sln` was attempted for confidence even though this is documentation-only. The first run hung without output. A second run with `--no-restore --verbosity normal` reached the VSTest target, reported `Build FAILED` with `0 Warning(s)` and `0 Error(s)`, then hung. I stopped only the test-spawned `dotnet` process cluster. No product code changed in this PR.

## Follow-Up Work

- **Add focused docs only after this file becomes crowded.** OpenAI's article recommends a short `AGENTS.md` as a table of contents once the knowledge base grows. The trigger here should be concrete: if architecture, release, UI verification, or quality guidance starts making this file harder to scan, split that topic into a focused repository-local doc and leave a pointer in `AGENTS.md`.

- **Promote repeated review comments into checks.** If future PRs repeatedly violate the same invariant, add a test, analyzer, or workflow check instead of expanding prose. That follows the harness engineering pattern of turning human taste and recurring failures into enforceable feedback loops.

- **Consider UI verification only when UI churn warrants it.** OpenAI highlights making app behavior directly legible to agents through screenshots, runtime signals, and repeatable validation loops. For Radial Actions, a lightweight manual checklist is probably enough today; a heavier WPF UI automation or screenshot harness should wait until visual regressions become frequent enough to justify the maintenance cost.

## Sources

- OpenAI, "Harness engineering: leveraging Codex in an agent-first world" (February 11, 2026): https://openai.com/index/harness-engineering/
- AGENTS.md open format guidance: https://agents.md/
