### PR TITLE
Make actions editor scrollable

### DIFF
--- a/RadialActions/Settings/ActionsSettingsView.xaml
+++ b/RadialActions/Settings/ActionsSettingsView.xaml
@@ -31,12 +31,13 @@
                   Style="{StaticResource SettingsCardGroupBox}">
             <Grid>
                 <Grid.RowDefinitions>
-                    <RowDefinition Height="*" MinHeight="150" />
+                    <RowDefinition Height="*" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <ListBox Grid.Row="0"
-                         MinHeight="150"
+                         ScrollViewer.VerticalScrollBarVisibility="Auto"
+                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                          ItemsSource="{Binding Actions}"
                          SelectedIndex="{Binding SelectedActionIndex}"
                          SelectedItem="{Binding SelectedAction}">
@@ -110,7 +111,10 @@
                   VerticalContentAlignment="Stretch"
                   Style="{StaticResource SettingsCardGroupBox}"
                   IsEnabled="{Binding Editor.HasSelectedAction}">
-            <local:ActionEditorView DataContext="{Binding Editor}" />
+            <ScrollViewer VerticalScrollBarVisibility="Auto"
+                          HorizontalScrollBarVisibility="Disabled">
+                <local:ActionEditorView DataContext="{Binding Editor}" />
+            </ScrollViewer>
         </GroupBox>
     </Grid>
 </UserControl>


### PR DESCRIPTION

- Make the actions list shrink with the settings window and rely on its built-in vertical scrolling.
- Wrap the right action editor pane in a vertical scroll viewer so all editor fields remain reachable in short windows.

<img width="740" height="343" alt="image" src="https://github.com/user-attachments/assets/7c88a53e-9e90-473f-acac-dc334c8b83c5" />
