### PR TITLE
Make settings helper text less visually noisy

### DIFF
--- a/RadialActions/Settings/ActionEditorView.xaml
+++ b/RadialActions/Settings/ActionEditorView.xaml
@@ -18,19 +18,19 @@
                    Style="{StaticResource ActionEditorLabelTextBlock}" />
         <CheckBox Content="Show this action in the menu"
                   IsChecked="{Binding SelectedAction.IsEnabled, Mode=TwoWay}" />
-        <TextBlock Text="Turn this off to keep the action configured without showing it as a menu slice."
+        <TextBlock Text="Hide this action without removing its configuration."
                    Style="{StaticResource DescriptionTextBlock}" />
 
         <TextBlock Text="Name:"
                    Style="{StaticResource ActionEditorLabelTextBlock}" />
         <TextBox Text="{Binding SelectedAction.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-        <TextBlock Text="This label appears next to the icon in the radial menu."
+        <TextBlock Text="Shown next to the icon in the radial menu."
                    Style="{StaticResource DescriptionTextBlock}" />
 
         <TextBlock Text="Icon:"
                    Style="{StaticResource ActionEditorLabelTextBlock}" />
         <TextBox Text="{Binding SelectedAction.Icon, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-        <TextBlock Text="Use a short symbol or emoji that fits inside the slice."
+        <TextBlock Text="Use a short symbol or emoji that fits in a slice."
                    Style="{StaticResource DescriptionTextBlock}" />
 
         <TextBlock Text="Type:"
@@ -51,7 +51,7 @@
                 </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>
-        <TextBlock Text="Choose Key for keyboard or media controls, or Shell to launch an app, file, folder, or URL."
+        <TextBlock Text="Use Key for shortcuts and media controls; Shell for apps, files, folders, URLs, or commands."
                    Style="{StaticResource DescriptionTextBlock}" />
 
         <StackPanel Margin="0,0,0,4"
@@ -75,7 +75,7 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-            <TextBlock Text="Pick a built-in media or volume command, or choose Custom Shortcut to enter one manually."
+            <TextBlock Text="Choose a built-in command or Custom Shortcut."
                        Style="{StaticResource DescriptionTextBlock}" />
 
             <TextBlock Text="Shortcut:"
@@ -83,7 +83,7 @@
                        Visibility="{Binding SelectedKeyActionId, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionEditorViewModel.CustomKeyActionId}}" />
             <TextBox Text="{Binding SelectedAction.Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                      Visibility="{Binding SelectedKeyActionId, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionEditorViewModel.CustomKeyActionId}}" />
-            <TextBlock Text="Enter a shortcut such as Ctrl+Shift+M when Custom Shortcut is selected."
+            <TextBlock Text="Enter a shortcut, such as Ctrl+Shift+M."
                        Style="{StaticResource DescriptionTextBlock}"
                        Visibility="{Binding SelectedKeyActionId, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionEditorViewModel.CustomKeyActionId}}" />
         </StackPanel>
@@ -105,13 +105,13 @@
                         Command="{Binding BrowseShellTargetCommand}"
                         Padding="8,2" />
             </Grid>
-            <TextBlock Text="Select the app, file, folder, URL, or command this action should open."
+            <TextBlock Text="Choose the app, file, folder, URL, or command to open."
                        Style="{StaticResource DescriptionTextBlock}" />
 
             <TextBlock Text="Arguments:"
                        Style="{StaticResource ActionEditorLabelTextBlock}" />
             <TextBox Text="{Binding SelectedAction.Arguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            <TextBlock Text="Optional command-line arguments passed to the target."
+            <TextBlock Text="Optional command-line arguments for the target."
                        Style="{StaticResource DescriptionTextBlock}" />
 
             <TextBlock Text="Working Directory:"
@@ -129,7 +129,7 @@
                         Command="{Binding BrowseWorkingDirectoryCommand}"
                         Padding="8,2" />
             </Grid>
-            <TextBlock Text="Optional folder used as the starting location when the target runs."
+            <TextBlock Text="Optional folder to use as the target's start location."
                        Style="{StaticResource DescriptionTextBlock}" />
         </StackPanel>
     </StackPanel>

--- a/RadialActions/Settings/AdvancedSettingsView.xaml
+++ b/RadialActions/Settings/AdvancedSettingsView.xaml
@@ -35,7 +35,7 @@
                 <StackPanel>
                     <CheckBox Content="Check for updates"
                               IsChecked="{Binding Settings.CheckForUpdatesOnStartup, Mode=TwoWay}" />
-                    <TextBlock Text="Checks the latest stable GitHub release on startup."
+                    <TextBlock Text="Checks GitHub for stable releases on startup."
                                Style="{StaticResource DescriptionTextBlock}" />
                 </StackPanel>
             </GroupBox>

--- a/RadialActions/Settings/GeneralSettingsView.xaml
+++ b/RadialActions/Settings/GeneralSettingsView.xaml
@@ -39,7 +39,7 @@
                                Style="{StaticResource LabelTextBlock}" />
                     <TextBox Text="{Binding Settings.ActivationHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                              Tag="ActivationHotkeyInput" />
-                    <TextBlock Text="Press the key combination directly (for example: Ctrl+Alt+Space, Ctrl+Shift+R, Win+Z)."
+                    <TextBlock Text="Press a key combination, such as Ctrl+Alt+Space."
                                Style="{StaticResource DescriptionTextBlock}" />
                 </StackPanel>
             </GroupBox>
@@ -53,7 +53,7 @@
                     <TextBlock Text="Menu Size (pixels):"
                                Style="{StaticResource LabelTextBlock}" />
                     <TextBox Text="{Binding Settings.Size, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                    <TextBlock Text="Recommended: 300-500"
+                    <TextBlock Text="Recommended range: 300-500 pixels."
                                Style="{StaticResource DescriptionTextBlock}" />
                 </StackPanel>
             </GroupBox>
@@ -66,12 +66,12 @@
                 <StackPanel>
                     <CheckBox Content="Keep menu open after clicking a slice"
                               IsChecked="{Binding Settings.KeepMenuOpenAfterSliceClick, Mode=TwoWay}" />
-                    <TextBlock Text="The menu stays open until you click another app or press Escape."
+                    <TextBlock Text="Keeps the menu open until Escape or focus changes."
                                Style="{StaticResource DescriptionTextBlock}" />
                     <CheckBox Margin="0,8,0,0"
                               Content="Always open menu in screen center"
                               IsChecked="{Binding Settings.OpenMenuInScreenCenter, Mode=TwoWay}" />
-                    <TextBlock Text="Useful for keyboard navigation when the pointer may be far from your focus."
+                    <TextBlock Text="Opens at screen center instead of the pointer."
                                Style="{StaticResource DescriptionTextBlock}" />
                 </StackPanel>
             </GroupBox>
@@ -84,7 +84,7 @@
                 <StackPanel>
                     <CheckBox Content="Run on Windows startup"
                               IsChecked="{Binding Settings.RunOnStartup, Mode=TwoWay}" />
-                    <TextBlock Text="Starts the app minimized to tray when you log in."
+                    <TextBlock Text="Starts Radial Actions minimized to the tray after sign-in."
                                Style="{StaticResource DescriptionTextBlock}" />
                 </StackPanel>
             </GroupBox>

--- a/RadialActions/Settings/SettingsViewResources.xaml
+++ b/RadialActions/Settings/SettingsViewResources.xaml
@@ -52,7 +52,9 @@
            BasedOn="{StaticResource {x:Type TextBlock}}">
         <Setter Property="FontStyle" Value="Normal" />
         <Setter Property="FontSize" Value="12" />
-        <Setter Property="Margin" Value="0,4,0,12" />
+        <Setter Property="LineHeight" Value="16" />
+        <Setter Property="Margin" Value="0,2,0,10" />
+        <Setter Property="Opacity" Value="0.72" />
         <Setter Property="TextWrapping" Value="Wrap" />
     </Style>
 


### PR DESCRIPTION
Tightens helper text across the settings window without reducing it to fragments; keeps action editor descriptions consistent and informative; adjusts the shared helper text style for readable dark-mode contrast while keeping it visually secondary.

Before

<img width="1186" height="793" alt="image" src="https://github.com/user-attachments/assets/a7fdeaaf-9a7c-43b4-8007-342d8fc4497f" />

<img width="1186" height="793" alt="image" src="https://github.com/user-attachments/assets/73f0833d-b5d4-4c0c-9448-a001ee5f3de3" />

After

<img width="1186" height="793" alt="image" src="https://github.com/user-attachments/assets/adb4a910-746d-43b5-823b-2549b2f27043" />

<img width="1186" height="793" alt="image" src="https://github.com/user-attachments/assets/2366f024-87ca-4caa-b07a-954cf36cc4ee" />
