### PR TITLE
Harden settings load and save safety

### DIFF
--- a/RadialActions.Tests/Settings/SettingsSerializationTests.cs
+++ b/RadialActions.Tests/Settings/SettingsSerializationTests.cs
@@ -109,4 +109,119 @@ public class SettingsSerializationTests
         Assert.Single(settings.Actions);
         Assert.True(settings.Actions[0].IsEnabled);
     }
+
+    [Fact]
+    public void Load_MalformedPrimary_PreservesCorruptPrimaryBeforeDefaultsCanSave()
+    {
+        var directory = CreateTempDirectory();
+        var settingsPath = Path.Combine(directory, "RadialActions.settings");
+        File.WriteAllText(settingsPath, "{");
+
+        var settings = Settings.LoadAndInitializePersistenceState(settingsPath, out var canBeSaved);
+
+        Assert.True(canBeSaved);
+        Assert.Equal(Settings.DefaultActivationHotkey, settings.ActivationHotkey);
+        Assert.Equal(Settings.DefaultSize, settings.Size);
+        Assert.Equal("{", File.ReadAllText(settingsPath));
+
+        var corruptPath = Assert.Single(Directory.GetFiles(directory, "RadialActions.settings.corrupt-*"));
+        Assert.Equal("{", File.ReadAllText(corruptPath));
+    }
+
+    [Fact]
+    public void Load_EmptyExistingFile_IsTreatedAsCorruptionNotFreshInstall()
+    {
+        var directory = CreateTempDirectory();
+        var settingsPath = Path.Combine(directory, "RadialActions.settings");
+        File.WriteAllText(settingsPath, string.Empty);
+
+        var settings = Settings.LoadFromFileWithRecovery(settingsPath);
+
+        Assert.Equal(Settings.DefaultActivationHotkey, settings.ActivationHotkey);
+        Assert.Equal(Settings.DefaultSize, settings.Size);
+        Assert.True(File.Exists(settingsPath));
+        Assert.Single(Directory.GetFiles(directory, "RadialActions.settings.corrupt-*"));
+    }
+
+    [Fact]
+    public void StartupWritableProbe_DoesNotRewriteSettingsFile()
+    {
+        var directory = CreateTempDirectory();
+        var settingsPath = Path.Combine(directory, "RadialActions.settings");
+        const string json = """
+        {
+          "ActivationHotkey": "Ctrl+Alt+P",
+          "Size": 480
+        }
+        """;
+        File.WriteAllText(settingsPath, json);
+        var lastWriteTime = new DateTime(2025, 1, 2, 3, 4, 5, DateTimeKind.Utc);
+        File.SetLastWriteTimeUtc(settingsPath, lastWriteTime);
+
+        var settings = Settings.LoadAndInitializePersistenceState(settingsPath, out var canBeSaved);
+
+        Assert.True(canBeSaved);
+        Assert.Equal("Ctrl+Alt+P", settings.ActivationHotkey);
+        Assert.Equal(json, File.ReadAllText(settingsPath));
+        Assert.Equal(lastWriteTime, File.GetLastWriteTimeUtc(settingsPath));
+    }
+
+    [Fact]
+    public void Load_LockedUnreadablePrimary_DisablesSavingRecoveredDefaults()
+    {
+        var directory = CreateTempDirectory();
+        var settingsPath = Path.Combine(directory, "RadialActions.settings");
+        File.WriteAllText(settingsPath, "{");
+
+        using var lockedSettingsFile = new FileStream(settingsPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+
+        var settings = Settings.LoadAndInitializePersistenceState(settingsPath, out var canBeSaved);
+
+        Assert.False(canBeSaved);
+        Assert.Equal(Settings.DefaultActivationHotkey, settings.ActivationHotkey);
+        Assert.Empty(Directory.GetFiles(directory, "RadialActions.settings.corrupt-*"));
+    }
+
+    [Fact]
+    public void Save_WritesAtomicallyAndLeavesNoTemporaryFileAfterSuccess()
+    {
+        var directory = CreateTempDirectory();
+        var settingsPath = Path.Combine(directory, "RadialActions.settings");
+        var settings = Settings.DeserializeFromJson("{}");
+        settings.ActivationHotkey = "Ctrl+Shift+S";
+        settings.Size = 640;
+
+        var saved = settings.SaveToFile(settingsPath);
+
+        Assert.True(saved);
+        Assert.Contains("Ctrl+Shift+S", File.ReadAllText(settingsPath));
+        Assert.Empty(Directory.GetFiles(directory, "*.tmp"));
+    }
+
+    [Fact]
+    public void Deserialize_PropertyLevelErrors_NormalizeWithoutDroppingUnrelatedValidSettings()
+    {
+        const string json = """
+        {
+          "ActivationHotkey": "Ctrl+Alt+L",
+          "Size": 420,
+          "Actions": "not a collection",
+          "OpenMenuInScreenCenter": true
+        }
+        """;
+
+        var settings = Settings.DeserializeFromJson(json);
+
+        Assert.Equal("Ctrl+Alt+L", settings.ActivationHotkey);
+        Assert.Equal(420, settings.Size);
+        Assert.True(settings.OpenMenuInScreenCenter);
+        Assert.Equal(Settings.CreateDefaultActions().Count, settings.Actions.Count);
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "RadialActions.Tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
 }

--- a/RadialActions/Properties/Settings.Engine.cs
+++ b/RadialActions/Properties/Settings.Engine.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+using System.Globalization;
+using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Newtonsoft.Json;
 
@@ -6,7 +7,16 @@ namespace RadialActions.Properties;
 
 public sealed partial class Settings : ObservableObject
 {
-    private static readonly Lazy<Settings> _default = new(LoadAndAttemptSave);
+    private static readonly Lazy<Settings> _default = new(LoadAndInitializePersistenceState);
+
+    /// <summary>
+    /// Carries loaded settings plus whether future saves are allowed to write back to the same path.
+    /// </summary>
+    /// <param name="Settings">The settings object to use for the current app session.</param>
+    /// <param name="CanSaveSettings">
+    /// <c>false</c> when the primary settings file existed but could not be preserved before recovery.
+    /// </param>
+    private sealed record SettingsLoadResult(Settings Settings, bool CanSaveSettings);
 
     private static readonly JsonSerializerSettings _jsonSerializerSettings = new()
     {
@@ -60,9 +70,20 @@ public sealed partial class Settings : ObservableObject
     /// <summary>
     /// Saves to the default path in JSON format.
     /// </summary>
+    /// <returns><c>true</c> when the default settings file was written successfully; otherwise, <c>false</c>.</returns>
     public bool Save()
     {
-        Log.Information($"Saving to {FilePath}");
+        return SaveToFile(FilePath);
+    }
+
+    /// <summary>
+    /// Saves this settings object to a specific path using an atomic file replacement.
+    /// </summary>
+    /// <param name="filePath">The primary settings file path to write.</param>
+    /// <returns><c>true</c> when the primary file was written successfully; otherwise, <c>false</c>.</returns>
+    internal bool SaveToFile(string filePath)
+    {
+        Log.Information("Saving to {FilePath}", filePath);
 
         try
         {
@@ -73,18 +94,17 @@ public sealed partial class Settings : ObservableObject
             {
                 try
                 {
-                    File.WriteAllText(FilePath, json);
+                    WriteAllTextAtomically(filePath, json);
                     return true;
                 }
-                catch
+                catch (Exception ex)
                 {
-                    // Wait before next attempt to read.
-                    Log.Debug("Couldn't save file; Waiting a bit");
+                    Log.Debug(ex, "Couldn't save file; waiting a bit");
                     Thread.Sleep(250);
                 }
             }
         }
-        catch (JsonSerializationException ex)
+        catch (JsonException ex)
         {
             Log.Error(ex, "Failed to save settings");
         }
@@ -92,11 +112,20 @@ public sealed partial class Settings : ObservableObject
         return false;
     }
 
+    /// <summary>
+    /// Serializes this settings object to the app's JSON settings format.
+    /// </summary>
+    /// <returns>The formatted JSON settings document.</returns>
     public string SerializeToJson()
     {
         return JsonConvert.SerializeObject(this, _jsonSerializerSettings);
     }
 
+    /// <summary>
+    /// Deserializes a settings document and normalizes missing or invalid values.
+    /// </summary>
+    /// <param name="json">The JSON settings content to deserialize.</param>
+    /// <returns>A normalized settings object.</returns>
     public static Settings DeserializeFromJson(string json)
     {
         var settings = new Settings();
@@ -110,46 +139,260 @@ public sealed partial class Settings : ObservableObject
     }
 
     /// <summary>
-    /// Reads settings from the default path.
+    /// Reads settings from the specified path.
     /// </summary>
-    private static string ReadJsonFromFile()
+    /// <param name="filePath">The settings file path to read.</param>
+    /// <returns>The complete JSON file content.</returns>
+    private static string ReadJsonFromFile(string filePath)
     {
-        using var fileStream = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         using var streamReader = new StreamReader(fileStream);
         return streamReader.ReadToEnd();
     }
 
     /// <summary>
-    /// Loads from the default path in JSON format.
+    /// Loads settings from the specified path with recovery behavior for unreadable primary files.
     /// </summary>
-    private static Settings LoadFromFile()
+    /// <param name="filePath">The primary settings file path.</param>
+    /// <returns>The settings object to use for the current app session.</returns>
+    internal static Settings LoadFromFileWithRecovery(string filePath)
+        => LoadFromFileWithRecoveryResult(filePath).Settings;
+
+    /// <summary>
+    /// Loads settings and records whether it is safe to save back to the primary path later.
+    /// </summary>
+    /// <param name="filePath">The primary settings file path.</param>
+    /// <returns>
+    /// A load result containing settings plus a save gate that protects unreadable files that could not be preserved.
+    /// </returns>
+    private static SettingsLoadResult LoadFromFileWithRecoveryResult(string filePath)
     {
+        if (!File.Exists(filePath))
+        {
+            Log.Information("Creating new settings because {FilePath} does not exist", filePath);
+            return new SettingsLoadResult(CreateDefaultSettings(), CanSaveSettings: true);
+        }
+
         try
         {
-            var json = ReadJsonFromFile();
-            return DeserializeFromJson(json);
+            var settings = LoadSettingsFileOrThrow(filePath);
+            return new SettingsLoadResult(settings, CanSaveSettings: true);
         }
         catch (Exception ex)
         {
-            Log.Error(ex, $"Failed to load {FilePath}");
-            Log.Information("Creating new settings");
-            var settings = new Settings();
-            settings.NormalizeAfterLoad();
-            return settings;
+            return RecoverFromPrimaryLoadFailure(filePath, ex);
         }
     }
 
     /// <summary>
-    /// Loads from the default path in JSON format then attempts to save in order to check if it can be done.
+    /// Loads from the default path in JSON format and probes whether the directory is writable.
     /// </summary>
-    private static Settings LoadAndAttemptSave()
+    /// <returns>The singleton settings object for the default settings file path.</returns>
+    private static Settings LoadAndInitializePersistenceState()
     {
-        var settings = LoadFromFile();
-
-        CanBeSaved = settings.Save();
-        Log.Debug($"Settings can be saved: {CanBeSaved}");
+        var settings = LoadAndInitializePersistenceState(FilePath, out var canBeSaved);
+        CanBeSaved = canBeSaved;
+        Log.Debug("Settings can be saved: {CanBeSaved}", CanBeSaved);
 
         return settings;
     }
 
+    /// <summary>
+    /// Loads settings from a specific path and determines whether later saves should be enabled.
+    /// </summary>
+    /// <param name="filePath">The primary settings file path.</param>
+    /// <param name="canBeSaved">
+    /// Set to <c>true</c> only when recovery did not need to suppress saves and the directory is writable.
+    /// </param>
+    /// <returns>The settings object to use for the current app session.</returns>
+    internal static Settings LoadAndInitializePersistenceState(string filePath, out bool canBeSaved)
+    {
+        var loadResult = LoadFromFileWithRecoveryResult(filePath);
+        canBeSaved = loadResult.CanSaveSettings && ProbeSettingsDirectoryWritable(filePath);
+        return loadResult.Settings;
+    }
+
+    /// <summary>
+    /// Checks whether the settings directory can be written without modifying the real settings file.
+    /// </summary>
+    /// <param name="filePath">The primary settings file path whose directory should be probed.</param>
+    /// <returns><c>true</c> when a throwaway probe file can be created and deleted; otherwise, <c>false</c>.</returns>
+    internal static bool ProbeSettingsDirectoryWritable(string filePath)
+    {
+        var directoryPath = Path.GetDirectoryName(filePath);
+        if (string.IsNullOrWhiteSpace(directoryPath))
+        {
+            directoryPath = ".";
+        }
+
+        var probePath = Path.Combine(directoryPath, $".settings-write-probe-{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            Directory.CreateDirectory(directoryPath);
+            File.WriteAllText(probePath, string.Empty);
+            File.Delete(probePath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Settings directory is not writable");
+            return false;
+        }
+        finally
+        {
+            TryDeleteFile(probePath);
+        }
+    }
+
+    /// <summary>
+    /// Creates a default settings object and runs the normal post-load normalization pass.
+    /// </summary>
+    /// <returns>A normalized default settings object.</returns>
+    private static Settings CreateDefaultSettings()
+    {
+        var settings = new Settings();
+        settings.NormalizeAfterLoad();
+        return settings;
+    }
+
+    /// <summary>
+    /// Reads and deserializes one settings file, treating an empty existing file as corruption.
+    /// </summary>
+    /// <param name="filePath">The settings file path to load.</param>
+    /// <returns>A normalized settings object.</returns>
+    /// <exception cref="InvalidDataException">Thrown when the file exists but contains no JSON content.</exception>
+    private static Settings LoadSettingsFileOrThrow(string filePath)
+    {
+        var json = ReadJsonFromFile(filePath);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            throw new InvalidDataException($"Settings file is empty: {filePath}");
+        }
+
+        return DeserializeFromJson(json);
+    }
+
+    /// <summary>
+    /// Recovers from a failed primary settings load without silently overwriting recoverable user data.
+    /// </summary>
+    /// <param name="filePath">The primary settings file path that failed to load.</param>
+    /// <param name="loadException">The exception raised while loading the primary file.</param>
+    /// <returns>
+    /// Recovered settings and a save gate. Saves are disabled when the unreadable primary file could not be copied aside.
+    /// </returns>
+    private static SettingsLoadResult RecoverFromPrimaryLoadFailure(string filePath, Exception loadException)
+    {
+        Log.Error(loadException, "Failed to load {FilePath}", filePath);
+
+        var canSaveDefaults = PreserveCorruptSettingsFile(filePath);
+        if (!canSaveDefaults)
+        {
+            Log.Warning("Default settings will not be saved automatically because the unreadable primary file could not be preserved");
+        }
+
+        Log.Information("Creating new settings in memory after unreadable settings file");
+        return new SettingsLoadResult(CreateDefaultSettings(), canSaveDefaults);
+    }
+
+    /// <summary>
+    /// Copies an unreadable primary settings file to a timestamped corrupt snapshot path.
+    /// </summary>
+    /// <param name="filePath">The primary settings file path to preserve.</param>
+    /// <returns>
+    /// <c>true</c> when no primary file exists or the copy succeeds; <c>false</c> when recovery should avoid saving.
+    /// </returns>
+    private static bool PreserveCorruptSettingsFile(string filePath)
+    {
+        if (!File.Exists(filePath))
+            return true;
+
+        var corruptPath = CreateCorruptFilePath(filePath);
+
+        try
+        {
+            using var source = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            using var destination = new FileStream(corruptPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+            source.CopyTo(destination);
+            Log.Warning("Preserved unreadable settings file at {CorruptPath}", corruptPath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to preserve unreadable settings file {FilePath}", filePath);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Creates a unique timestamped corrupt snapshot path for a settings file.
+    /// </summary>
+    /// <param name="filePath">The primary settings file path.</param>
+    /// <returns>A non-existing path using the `.corrupt-*` naming pattern.</returns>
+    private static string CreateCorruptFilePath(string filePath)
+    {
+        var timestamp = DateTimeOffset.UtcNow.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture);
+        for (var attempt = 0; ; attempt++)
+        {
+            var suffix = attempt == 0 ? string.Empty : $"-{attempt}";
+            var corruptPath = $"{filePath}.corrupt-{timestamp}{suffix}";
+            if (!File.Exists(corruptPath))
+            {
+                return corruptPath;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Writes text through a same-directory temporary file and atomically replaces the destination when possible.
+    /// </summary>
+    /// <param name="filePath">The destination file path.</param>
+    /// <param name="contents">The complete content to write.</param>
+    private static void WriteAllTextAtomically(string filePath, string contents)
+    {
+        var directoryPath = Path.GetDirectoryName(filePath);
+        if (string.IsNullOrWhiteSpace(directoryPath))
+        {
+            directoryPath = ".";
+        }
+
+        Directory.CreateDirectory(directoryPath);
+        var tempFilePath = Path.Combine(directoryPath, $"{Path.GetFileName(filePath)}.{Guid.NewGuid():N}.tmp");
+
+        try
+        {
+            File.WriteAllText(tempFilePath, contents);
+            if (File.Exists(filePath))
+            {
+                File.Replace(tempFilePath, filePath, null);
+            }
+            else
+            {
+                File.Move(tempFilePath, filePath);
+            }
+        }
+        finally
+        {
+            TryDeleteFile(tempFilePath);
+        }
+    }
+
+    /// <summary>
+    /// Deletes a file when it exists, logging and ignoring cleanup failures.
+    /// </summary>
+    /// <param name="filePath">The file path to delete.</param>
+    private static void TryDeleteFile(string filePath)
+    {
+        try
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Debug(ex, "Failed to delete temporary file {FilePath}", filePath);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Part of #46.

This PR keeps the settings resiliency work narrowly focused on direct data-loss prevention:

- stops startup from saving the real settings file just to compute `CanBeSaved`
- probes writeability with a throwaway temp file in the settings directory
- treats malformed or empty existing settings files as corruption, not first-run defaults
- preserves unreadable primary settings files as `.corrupt-*` snapshots before fallback defaults can be saved
- disables saving for the run if an unreadable primary file cannot be copied aside
- writes settings through a same-directory temp file before replacing/moving into the primary path
- adds deterministic tests for those behaviors and property-level deserialization resilience

## Out Of Scope

This intentionally removes the broader pieces from the first draft:

- no MSI/package changes in this PR
- no graceful installer close or exit-time save
- no `.lastgood` backup/automatic restore flow
- no settings relocation out of the executable-adjacent directory

The MSI wildcard cleanup is split into a separate PR so it can be reviewed and reverted independently.

## Validation

- `dotnet build RadialActions.sln`
- `dotnet test RadialActions.sln` (68 passed)
