### PR TITLE
Fix user settings deleted on update

### DIFF
--- a/Package.wxs
+++ b/Package.wxs
@@ -40,7 +40,6 @@
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
       <Component Id="MainExecutable" Guid="*">
         <File Id="RadialActionsExe" Source="publish/$(var.Arch)/RadialActions.exe" KeyPath="yes" />
-        <RemoveFile Id="RemoveOldFiles" Name="*.*" On="both" />
         <RemoveFolder Id="RemoveInstallFolder" Directory="INSTALLFOLDER" On="uninstall" />
       </Component>
       <Component Id="StartMenuShortcut" Guid="*">


### PR DESCRIPTION
## Summary

Part of #46.

This is the smallest installer data-safety change from the issue: remove the wildcard `RemoveFile Name="*.*"` cleanup from the main executable component.

Settings currently live beside the executable, so wildcard-deleting the install folder can remove user-owned files such as:

- `RadialActions.settings`
- `.corrupt-*` recovery snapshots from the settings safety PR
- any other user-owned files in the per-user install directory

The existing `RemoveFolder` entry remains. Windows Installer can still remove the install folder when it is empty, but the MSI no longer deletes files it does not own just to make cleanup look complete.

## Out Of Scope

- no WiX Util `CloseApplication`
- no graceful app shutdown/save changes
- no settings relocation
- no backup/restore recovery flow

## Validation

- `dotnet test RadialActions.sln` (62 passed)
- `dotnet publish .\RadialActions\RadialActions.csproj -o publish\x64 -c Release -f net10.0-windows --os win --arch x64 --self-contained -p:PublishSingleFile=true -p:DebugType=embedded -p:Version=1.2.3`
- WiX 6.0.2 x64 MSI build: `wix build Package.wxs -arch x64 -d Version=1.2.3 -d Arch=x64 -o publish\RadialActions-1.2.3-x64.msi`
