### PR TITLE
Harden settings persistence against corruption

### DIFF
--- a/RadialActions.Tests/Settings/SettingsPersistenceTests.cs
+++ b/RadialActions.Tests/Settings/SettingsPersistenceTests.cs
@@ -1,0 +1,120 @@
+using RadialActions.Properties;
+
+namespace RadialActions.Tests;
+
+public class SettingsPersistenceTests : IDisposable
+{
+    private readonly string _directory;
+    private readonly string _filePath;
+
+    public SettingsPersistenceTests()
+    {
+        _directory = Path.Combine(Path.GetTempPath(), "RadialActionsTests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_directory);
+        _filePath = Path.Combine(_directory, "Test.settings");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+        catch
+        {
+            // Leftover temp directories are harmless.
+        }
+    }
+
+    private static Settings CreateSettings(string hotkey)
+    {
+        var settings = Settings.DeserializeFromJson("{}");
+        settings.ActivationHotkey = hotkey;
+        return settings;
+    }
+
+    private string BackupPath => _filePath + ".bak";
+
+    private string[] CorruptCopies => Directory.GetFiles(_directory, "*.corrupt-*");
+
+    [Fact]
+    public void SaveToFile_KeepsPreviousVersionAsBackup()
+    {
+        Assert.True(CreateSettings("Ctrl+1").SaveToFile(_filePath));
+        Assert.True(CreateSettings("Ctrl+2").SaveToFile(_filePath));
+
+        var current = Settings.LoadFromFile(_filePath, out var canBeSaved);
+        Assert.True(canBeSaved);
+        Assert.Equal("Ctrl+2", current.ActivationHotkey);
+
+        var backup = Settings.DeserializeFromJson(File.ReadAllText(BackupPath));
+        Assert.Equal("Ctrl+1", backup.ActivationHotkey);
+
+        Assert.Empty(Directory.GetFiles(_directory, "*.tmp"));
+    }
+
+    [Fact]
+    public void LoadFromFile_MissingFile_ReturnsDefaults()
+    {
+        var settings = Settings.LoadFromFile(_filePath, out var canBeSaved);
+
+        Assert.True(canBeSaved);
+        Assert.Equal(Settings.DefaultActivationHotkey, settings.ActivationHotkey);
+        Assert.Empty(CorruptCopies);
+    }
+
+    [Fact]
+    public void LoadFromFile_EmptyFile_RestoresFromBackup()
+    {
+        File.WriteAllText(_filePath, string.Empty);
+        CreateSettings("Ctrl+9").SaveToFile(BackupPath);
+        File.Delete(BackupPath + ".bak");
+
+        var settings = Settings.LoadFromFile(_filePath, out var canBeSaved);
+
+        Assert.True(canBeSaved);
+        Assert.Equal("Ctrl+9", settings.ActivationHotkey);
+        Assert.Single(CorruptCopies);
+    }
+
+    [Fact]
+    public void LoadFromFile_CorruptFile_RestoresFromBackup()
+    {
+        const string garbage = "!!!not json!!!";
+        File.WriteAllText(_filePath, garbage);
+        CreateSettings("Ctrl+9").SaveToFile(BackupPath);
+        File.Delete(BackupPath + ".bak");
+
+        var settings = Settings.LoadFromFile(_filePath, out var canBeSaved);
+
+        Assert.True(canBeSaved);
+        Assert.Equal("Ctrl+9", settings.ActivationHotkey);
+        Assert.Equal(garbage, File.ReadAllText(Assert.Single(CorruptCopies)));
+        Assert.Equal(garbage, File.ReadAllText(_filePath));
+    }
+
+    [Fact]
+    public void LoadFromFile_CorruptFile_WithoutBackup_ReturnsDefaults()
+    {
+        File.WriteAllText(_filePath, "{\"ActivationHotkey\":");
+
+        var settings = Settings.LoadFromFile(_filePath, out var canBeSaved);
+
+        Assert.True(canBeSaved);
+        Assert.Equal(Settings.DefaultActivationHotkey, settings.ActivationHotkey);
+        Assert.Single(CorruptCopies);
+    }
+
+    [Fact]
+    public void LoadFromFile_UnreadableFile_DisablesSaving()
+    {
+        File.WriteAllText(_filePath, "{}");
+        using var exclusiveLock = new FileStream(_filePath, FileMode.Open, FileAccess.Read, FileShare.None);
+
+        var settings = Settings.LoadFromFile(_filePath, out var canBeSaved);
+
+        Assert.False(canBeSaved);
+        Assert.Equal(Settings.DefaultActivationHotkey, settings.ActivationHotkey);
+        Assert.Empty(CorruptCopies);
+    }
+}

--- a/RadialActions/Properties/Settings.Engine.cs
+++ b/RadialActions/Properties/Settings.Engine.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace RadialActions.Properties;
 
@@ -146,6 +147,10 @@ public sealed partial class Settings : ObservableObject
         var settings = new Settings();
         if (!string.IsNullOrWhiteSpace(json))
         {
+            // Reject malformed documents up front so corrupt files trigger recovery;
+            // the serializer's error handler would otherwise swallow syntax errors and quietly load defaults.
+            JToken.Parse(json);
+
             JsonConvert.PopulateObject(json, settings, _jsonSerializerSettings);
         }
 

--- a/RadialActions/Properties/Settings.Engine.cs
+++ b/RadialActions/Properties/Settings.Engine.cs
@@ -6,7 +6,7 @@ namespace RadialActions.Properties;
 
 public sealed partial class Settings : ObservableObject
 {
-    private static readonly Lazy<Settings> _default = new(LoadAndAttemptSave);
+    private static readonly Lazy<Settings> _default = new(LoadAndProbeWritability);
 
     private static readonly JsonSerializerSettings _jsonSerializerSettings = new()
     {
@@ -253,16 +253,36 @@ public sealed partial class Settings : ObservableObject
     }
 
     /// <summary>
-    /// Loads from the default path in JSON format then attempts to save in order to check if it can be done.
+    /// Loads from the default path in JSON format then probes whether the file could be saved later.
     /// </summary>
-    private static Settings LoadAndAttemptSave()
+    private static Settings LoadAndProbeWritability()
     {
         var settings = LoadFromFile(FilePath, out var canBeSaved);
 
-        CanBeSaved = canBeSaved && settings.Save();
+        CanBeSaved = canBeSaved && ProbeCanWrite(FilePath);
         Log.Debug($"Settings can be saved: {CanBeSaved}");
 
         return settings;
+    }
+
+    /// <summary>
+    /// Checks that the settings folder is writable without touching the settings file itself.
+    /// </summary>
+    private static bool ProbeCanWrite(string filePath)
+    {
+        var probePath = filePath + ".probe.tmp";
+
+        try
+        {
+            File.WriteAllText(probePath, string.Empty);
+            File.Delete(probePath);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Settings folder is not writable");
+            return false;
+        }
     }
 
 }

--- a/RadialActions/Properties/Settings.Engine.cs
+++ b/RadialActions/Properties/Settings.Engine.cs
@@ -154,32 +154,101 @@ public sealed partial class Settings : ObservableObject
     }
 
     /// <summary>
-    /// Reads settings from the default path.
+    /// Reads settings from the given path.
     /// </summary>
-    private static string ReadJsonFromFile()
+    private static string ReadJsonFromFile(string filePath)
     {
-        using var fileStream = new FileStream(FilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+        using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         using var streamReader = new StreamReader(fileStream);
         return streamReader.ReadToEnd();
     }
 
     /// <summary>
-    /// Loads from the default path in JSON format.
+    /// Loads a single settings file, treating an existing but empty file as corrupt.
     /// </summary>
-    private static Settings LoadFromFile()
+    private static Settings LoadSettingsFile(string filePath)
     {
+        var json = ReadJsonFromFile(filePath);
+
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            throw new InvalidDataException($"Settings file is empty: {filePath}");
+        }
+
+        return DeserializeFromJson(json);
+    }
+
+    /// <summary>
+    /// Loads from the given path in JSON format, recovering from an unreadable file instead of silently resetting.
+    /// </summary>
+    /// <param name="canBeSaved">
+    /// <c>false</c> when the file is unreadable and couldn't be copied aside, so saving would destroy it.
+    /// </param>
+    internal static Settings LoadFromFile(string filePath, out bool canBeSaved)
+    {
+        canBeSaved = true;
+
+        if (!File.Exists(filePath))
+        {
+            Log.Information("No settings file; Creating new settings");
+            return CreateDefault();
+        }
+
         try
         {
-            var json = ReadJsonFromFile();
-            return DeserializeFromJson(json);
+            return LoadSettingsFile(filePath);
         }
         catch (Exception ex)
         {
-            Log.Error(ex, $"Failed to load {FilePath}");
-            Log.Information("Creating new settings");
-            var settings = new Settings();
-            settings.NormalizeAfterLoad();
-            return settings;
+            Log.Error(ex, $"Failed to load {filePath}");
+        }
+
+        // Keep the unreadable file for manual recovery; never save over it if that fails.
+        canBeSaved = TryPreserveCorruptFile(filePath);
+
+        var backupPath = BackupPath(filePath);
+        if (File.Exists(backupPath))
+        {
+            try
+            {
+                var settings = LoadSettingsFile(backupPath);
+                Log.Warning($"Restored settings from backup {backupPath}");
+                return settings;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, $"Failed to load backup {backupPath}");
+            }
+        }
+
+        Log.Information("Creating new settings");
+        return CreateDefault();
+    }
+
+    private static Settings CreateDefault()
+    {
+        var settings = new Settings();
+        settings.NormalizeAfterLoad();
+        return settings;
+    }
+
+    /// <summary>
+    /// Copies an unreadable settings file to a timestamped path so it can be recovered manually.
+    /// </summary>
+    private static bool TryPreserveCorruptFile(string filePath)
+    {
+        var corruptPath = $"{filePath}.corrupt-{DateTime.UtcNow:yyyyMMddHHmmss}";
+
+        try
+        {
+            File.Copy(filePath, corruptPath, overwrite: true);
+            Log.Warning($"Preserved unreadable settings file at {corruptPath}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, $"Failed to preserve unreadable settings file {filePath}");
+            return false;
         }
     }
 
@@ -188,9 +257,9 @@ public sealed partial class Settings : ObservableObject
     /// </summary>
     private static Settings LoadAndAttemptSave()
     {
-        var settings = LoadFromFile();
+        var settings = LoadFromFile(FilePath, out var canBeSaved);
 
-        CanBeSaved = settings.Save();
+        CanBeSaved = canBeSaved && settings.Save();
         Log.Debug($"Settings can be saved: {CanBeSaved}");
 
         return settings;

--- a/RadialActions/Properties/Settings.Engine.cs
+++ b/RadialActions/Properties/Settings.Engine.cs
@@ -60,9 +60,14 @@ public sealed partial class Settings : ObservableObject
     /// <summary>
     /// Saves to the default path in JSON format.
     /// </summary>
-    public bool Save()
+    public bool Save() => SaveToFile(FilePath);
+
+    /// <summary>
+    /// Saves to the given path in JSON format, keeping the previous version as a backup.
+    /// </summary>
+    internal bool SaveToFile(string filePath)
     {
-        Log.Information($"Saving to {FilePath}");
+        Log.Information($"Saving to {filePath}");
 
         try
         {
@@ -73,7 +78,7 @@ public sealed partial class Settings : ObservableObject
             {
                 try
                 {
-                    File.WriteAllText(FilePath, json);
+                    WriteAllTextAtomically(filePath, json);
                     return true;
                 }
                 catch
@@ -91,6 +96,45 @@ public sealed partial class Settings : ObservableObject
 
         return false;
     }
+
+    /// <summary>
+    /// Writes through a temporary file and replaces the destination atomically so a crash mid-write can't truncate it.
+    /// The previous version is kept next to the file as a last-known-good backup.
+    /// </summary>
+    private static void WriteAllTextAtomically(string filePath, string contents)
+    {
+        var tempFilePath = filePath + ".tmp";
+
+        try
+        {
+            File.WriteAllText(tempFilePath, contents);
+
+            if (File.Exists(filePath))
+            {
+                File.Replace(tempFilePath, filePath, BackupPath(filePath));
+            }
+            else
+            {
+                File.Move(tempFilePath, filePath);
+            }
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(tempFilePath);
+            }
+            catch
+            {
+                // A leftover temp file is harmless; it gets overwritten by the next save.
+            }
+        }
+    }
+
+    /// <summary>
+    /// The path of the last-known-good backup kept alongside a settings file.
+    /// </summary>
+    private static string BackupPath(string filePath) => filePath + ".bak";
 
     public string SerializeToJson()
     {

--- a/RadialActions/Settings/AdvancedSettingsView.xaml
+++ b/RadialActions/Settings/AdvancedSettingsView.xaml
@@ -4,7 +4,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="clr-namespace:RadialActions"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:p="clr-namespace:RadialActions.Properties"
              d:DataContext="{d:DesignInstance Type=local:AdvancedSettingsViewModel}"
              mc:Ignorable="d">
     <UserControl.Resources>
@@ -90,8 +89,7 @@
                                 Margin="0,0,0,8" />
                         <Button Content="Open Settings File"
                                 Command="{Binding OpenSettingsFileCommand}"
-                                Margin="0,0,0,8"
-                                IsEnabled="{x:Static p:Settings.CanBeSaved}" />
+                                Margin="0,0,0,8" />
                     </StackPanel>
                 </GroupBox>
             </Grid>


### PR DESCRIPTION
Closes #46

The root cause of settings loss on upgrade (the MSI wildcard `RemoveFile`) was already fixed in #48. This PR addresses the remaining gap: a corrupt or truncated settings file currently resets to defaults and is overwritten at startup, making the loss permanent.

## Changes

- **Atomic saves with a free last-known-good backup** — `Save()` now writes through a temp file and swaps it in with `File.Replace`, which also keeps the previous version as `RadialActions.settings.bak`. A crash mid-write can no longer truncate the file.
- **Recovery instead of silent reset** — on an unreadable/corrupt file, the load path now: preserves it as `RadialActions.settings.corrupt-<timestamp>`, restores from `.bak` if it parses, and only then falls back to defaults. If the corrupt file can't even be copied aside, saving is disabled for the session so it's never overwritten.
- **No more probe-save at startup** — startup used to test writability by calling `Save()`, which clobbered corrupt files with defaults before anyone could recover them. It now creates and deletes a throwaway probe file instead.
- **Malformed documents are detected** — the serializer's error handler was swallowing syntax-level errors, so truncated files quietly loaded as defaults and never triggered recovery. `DeserializeFromJson` now validates document syntax with `JToken.Parse` first; property-level salvage (bad enum values, nulls) is unchanged.

## From issue #46, intentionally not done

- **WiX `CloseApplication` / `OnExit` save** — settings are saved when the settings window closes, so there is no meaningful dirty in-memory state to lose during a force-kill upgrade.
- **Relocating settings to AppData** — MSI installs already live under `%LocalAppData%`, and the portable build intentionally keeps settings next to the exe.
- **Settings version field** — `NormalizeAfterLoad()` plus per-property error handling already cover schema evolution.

## Testing

- 6 new file-based tests: atomic save + `.bak` rotation, missing file, empty file, corrupt file with/without backup, unreadable (locked) file disabling saves. 68/68 pass.
- Manual smoke on the built app: first run creates no file at startup; a garbage settings file with a valid `.bak` gets preserved as `.corrupt-<timestamp>` and the app starts from the backup, leaving the original bytes untouched.