### PR TITLE
Drag and drop slices to reorder them

### DIFF
--- a/RadialActions.Tests/Pie/PieReorderCalculatorTests.cs
+++ b/RadialActions.Tests/Pie/PieReorderCalculatorTests.cs
@@ -1,0 +1,77 @@
+using System.Windows;
+
+namespace RadialActions.Tests;
+
+public class PieReorderCalculatorTests
+{
+    [Theory]
+    [InlineData(100, 0, 0)]     // right
+    [InlineData(0, 100, 90)]    // down
+    [InlineData(-100, 0, 180)]  // left
+    [InlineData(0, -100, -90)]  // up
+    public void GetPointerAngle_MatchesSliceLayoutConvention(double dx, double dy, double expectedAngle)
+    {
+        var center = new Point(200, 200);
+
+        var angle = PieReorderCalculator.GetPointerAngle(center, new Point(center.X + dx, center.Y + dy));
+
+        Assert.Equal(expectedAngle, angle, precision: 6);
+    }
+
+    [Theory]
+    [InlineData(0, 0, 0)]       // no rotation stays put
+    [InlineData(0, 30, 0)]      // less than half a slot rounds back
+    [InlineData(0, 40, 1)]      // more than half a slot advances
+    [InlineData(0, 144, 2)]     // two slots clockwise
+    [InlineData(0, -72, 4)]     // one slot counterclockwise wraps
+    [InlineData(4, 72, 0)]      // last slice wraps forward to first slot
+    [InlineData(0, 360, 0)]     // full revolution lands back home
+    [InlineData(2, -216, 4)]    // multiple slots counterclockwise wraps
+    public void GetTargetSlot_MapsRotationToSlot(int originalIndex, double rotationOffset, int expectedSlot)
+    {
+        const double angleStep = 72;
+        const int sliceCount = 5;
+
+        var slot = PieReorderCalculator.GetTargetSlot(originalIndex, rotationOffset, angleStep, sliceCount);
+
+        Assert.Equal(expectedSlot, slot);
+    }
+
+    [Theory]
+    [InlineData(0, 288, -72)]    // short way is backward
+    [InlineData(300, 0, 360)]    // short way keeps going forward
+    [InlineData(-10, 0, 0)]      // already closest
+    [InlineData(-350, 0, -360)]  // stays near the current winding
+    public void GetNearestEquivalentAngle_TakesShortWayAround(double currentAngle, double targetAngle, double expectedAngle)
+    {
+        var angle = PieReorderCalculator.GetNearestEquivalentAngle(currentAngle, targetAngle);
+
+        Assert.Equal(expectedAngle, angle, precision: 6);
+    }
+
+    [Fact]
+    public void GetSlotAssignments_DraggedForwardShiftsOthersBack()
+    {
+        var slots = PieReorderCalculator.GetSlotAssignments(sliceCount: 5, draggedIndex: 0, targetSlot: 2);
+
+        // Original order 0,1,2,3,4 with 0 floating over slot 2 -> 1,2,0,3,4.
+        Assert.Equal([2, 0, 1, 3, 4], slots);
+    }
+
+    [Fact]
+    public void GetSlotAssignments_DraggedBackwardShiftsOthersForward()
+    {
+        var slots = PieReorderCalculator.GetSlotAssignments(sliceCount: 5, draggedIndex: 4, targetSlot: 0);
+
+        // Original order 0,1,2,3,4 with 4 floating over slot 0 -> 4,0,1,2,3.
+        Assert.Equal([1, 2, 3, 4, 0], slots);
+    }
+
+    [Fact]
+    public void GetSlotAssignments_TargetSlotIsOriginalIndexKeepsOrder()
+    {
+        var slots = PieReorderCalculator.GetSlotAssignments(sliceCount: 3, draggedIndex: 1, targetSlot: 1);
+
+        Assert.Equal([0, 1, 2], slots);
+    }
+}

--- a/RadialActions/MainWindow.xaml
+++ b/RadialActions/MainWindow.xaml
@@ -101,5 +101,6 @@
                       CenterContextMenuRequested="OnCenterContextMenuRequested"
                       SliceClicked="OnSliceClicked"
                       SliceEditRequested="OnSliceEditRequested"
+                      SlicesReordered="OnSlicesReordered"
                       Slices="{Binding Actions, Source={x:Static p:Settings.Default}}" />
 </Window>

--- a/RadialActions/MainWindow.xaml.cs
+++ b/RadialActions/MainWindow.xaml.cs
@@ -206,6 +206,15 @@ public partial class MainWindow : Window
         }
     }
 
+    private void OnSlicesReordered(object sender, EventArgs e)
+    {
+        Log.Debug("Slices reordered by dragging");
+        if (Settings.CanBeSaved)
+        {
+            Settings.Default.Save();
+        }
+    }
+
     private void OnCenterClicked(object sender, EventArgs e)
     {
         Log.Debug("Center close target clicked");

--- a/RadialActions/Pie/PieAnimationService.cs
+++ b/RadialActions/Pie/PieAnimationService.cs
@@ -76,9 +76,40 @@ internal sealed class PieAnimationService
         element.BeginAnimation(UIElement.OpacityProperty, opacityAnimation, HandoffBehavior.SnapshotAndReplace);
     }
 
+    public void AnimateRotationAngle(
+        RotateTransform transform,
+        double toAngle,
+        Duration duration,
+        IEasingFunction easingFunction,
+        Action onCompleted = null)
+    {
+        if (IsReducedMotionEnabled())
+        {
+            transform.BeginAnimation(RotateTransform.AngleProperty, null);
+            transform.Angle = toAngle;
+            onCompleted?.Invoke();
+            return;
+        }
+
+        var rotationAnimation = new DoubleAnimation
+        {
+            To = toAngle,
+            Duration = duration,
+            EasingFunction = easingFunction,
+        };
+
+        if (onCompleted != null)
+        {
+            rotationAnimation.Completed += (_, _) => onCompleted();
+        }
+
+        transform.BeginAnimation(RotateTransform.AngleProperty, rotationAnimation, HandoffBehavior.SnapshotAndReplace);
+    }
+
     public void AnimateClickDown(UIElement target, Duration duration, IEasingFunction easingFunction)
     {
-        if (target.RenderTransform is not ScaleTransform scaleTransform)
+        var scaleTransform = FindScaleTransform(target);
+        if (scaleTransform == null)
         {
             scaleTransform = new ScaleTransform(1, 1);
             target.RenderTransform = scaleTransform;
@@ -108,7 +139,8 @@ internal sealed class PieAnimationService
 
     public void AnimateClickUp(UIElement target, Duration duration, IEasingFunction easingFunction)
     {
-        if (target.RenderTransform is not ScaleTransform scaleTransform)
+        var scaleTransform = FindScaleTransform(target);
+        if (scaleTransform == null)
         {
             return;
         }
@@ -136,5 +168,15 @@ internal sealed class PieAnimationService
     public static bool IsReducedMotionEnabled()
     {
         return !SystemParameters.ClientAreaAnimation;
+    }
+
+    private static ScaleTransform FindScaleTransform(UIElement target)
+    {
+        return target.RenderTransform switch
+        {
+            ScaleTransform scaleTransform => scaleTransform,
+            TransformGroup transformGroup => transformGroup.Children.OfType<ScaleTransform>().FirstOrDefault(),
+            _ => null,
+        };
     }
 }

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -24,6 +24,14 @@ public partial class PieControl : UserControl
     private const int DraggedSliceZIndex = 16;
     private const int DraggedSliceContentZIndex = 17;
     private const double MouseMoveThreshold = 0.25;
+
+    /// <summary>
+    /// How far the pointer must travel with the button held before a press becomes a drag.
+    /// Deliberately much larger than the system drag threshold so held-but-jittering clicks
+    /// during normal use never start reordering.
+    /// </summary>
+    private const double DragStartThreshold = 20;
+
     private static readonly Duration ReorderDuration = new(TimeSpan.FromMilliseconds(150));
 
     private enum InteractionMode
@@ -667,8 +675,8 @@ public partial class PieControl : UserControl
         }
 
         var position = e.GetPosition(PieCanvas);
-        if (Math.Abs(position.X - _dragPressPosition.X) < SystemParameters.MinimumHorizontalDragDistance
-            && Math.Abs(position.Y - _dragPressPosition.Y) < SystemParameters.MinimumVerticalDragDistance)
+        var distance = (position - _dragPressPosition).Length;
+        if (distance < DragStartThreshold)
         {
             return;
         }

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -20,7 +20,11 @@ public partial class PieControl : UserControl
     private const double DefaultCenterHoleRatio = 0.25;
     private const int SliceZIndex = 10;
     private const int HoveredSliceZIndex = 14;
+    private const int SliceContentZIndex = 15;
+    private const int DraggedSliceZIndex = 16;
+    private const int DraggedSliceContentZIndex = 17;
     private const double MouseMoveThreshold = 0.25;
+    private static readonly Duration ReorderDuration = new(TimeSpan.FromMilliseconds(150));
 
     private enum InteractionMode
     {
@@ -38,6 +42,20 @@ public partial class PieControl : UserControl
     private InteractionMode _interactionMode = InteractionMode.Mouse;
     private Point _keyboardModeMousePosition;
     private bool _hasKeyboardModeMousePosition;
+    private Point _layoutCenter;
+    private double _layoutAngleStep;
+    private PieSliceVisual _dragCandidate;
+    private Point _dragPressPosition;
+    private DragReorderState _drag;
+    private bool _isReleasingDragCapture;
+
+    private sealed class DragReorderState
+    {
+        public required PieSliceVisual Slice { get; init; }
+        public required double LastPointerAngle { get; set; }
+        public required double RotationOffset { get; set; }
+        public required int TargetSlot { get; set; }
+    }
 
     public PieControl()
     {
@@ -245,13 +263,14 @@ public partial class PieControl : UserControl
 
     private void CreatePieMenu()
     {
-        const int contentZIndex = 15;
         const int centerZIndex = 20;
 
         PieCanvas.Children.Clear();
         _sliceVisuals.Clear();
         _centerVisual = null;
         _renderRefreshPending = false;
+        _drag = null;
+        _dragCandidate = null;
 
         var enabledSlices = Slices?
             .Where(slice => slice?.IsEnabled == true)
@@ -313,6 +332,8 @@ public partial class PieControl : UserControl
             theme.AmbientShadowEffect);
 
         var angleStep = layout.AngleStep;
+        _layoutCenter = center;
+        _layoutAngleStep = angleStep;
 
         if (innerRadius > 0)
         {
@@ -436,6 +457,16 @@ public partial class PieControl : UserControl
             slice.Cursor = Cursors.Hand;
             slice.SnapsToDevicePixels = true;
 
+            // Press scale and reorder rotation live in one group so both effects can apply at once.
+            var pathBounds = slice.Data.Bounds;
+            var pressScale = new ScaleTransform(1, 1)
+            {
+                CenterX = pathBounds.X + (pathBounds.Width / 2),
+                CenterY = pathBounds.Y + (pathBounds.Height / 2),
+            };
+            var reorderRotation = new RotateTransform(0, center.X, center.Y);
+            slice.RenderTransform = new TransformGroup { Children = { pressScale, reorderRotation } };
+
             var contextMenu = CreateSliceContextMenu(sliceAction);
             slice.ContextMenu = contextMenu;
 
@@ -448,6 +479,8 @@ public partial class PieControl : UserControl
                 FillBrush = fillBrush,
                 StrokeBrush = strokeBrush,
                 ContextMenu = contextMenu,
+                PathRotation = reorderRotation,
+                CurrentSlot = i,
             };
             _sliceVisuals.Add(sliceVisual);
 
@@ -460,11 +493,23 @@ public partial class PieControl : UserControl
                 _animationService.AnimateBrushColor(fillBrush, theme.PressedColor, pressDuration, _renderState.StandardEasing);
                 _animationService.AnimateBrushColor(strokeBrush, _renderState.BorderHoverColor, pressDuration, _renderState.StandardEasing);
                 _animationService.AnimateClickDown(slice, pressDuration, _renderState.StandardEasing);
+                BeginDragTracking(sliceVisual, e.GetPosition(PieCanvas));
                 e.Handled = true;
             };
 
+            slice.MouseMove += (_, e) => HandleSliceMouseMove(sliceVisual, e);
+
+            slice.LostMouseCapture += (_, _) => OnSliceLostMouseCapture(sliceVisual);
+
             slice.MouseLeftButtonUp += (_, e) =>
             {
+                if (EndDragTracking(sliceVisual))
+                {
+                    isMouseDown = false;
+                    e.Handled = true;
+                    return;
+                }
+
                 if (!isMouseDown)
                 {
                     return;
@@ -494,7 +539,7 @@ public partial class PieControl : UserControl
 
             slice.MouseEnter += (_, _) =>
             {
-                if (_interactionMode != InteractionMode.Mouse)
+                if (_interactionMode != InteractionMode.Mouse || _drag != null)
                 {
                     return;
                 }
@@ -504,7 +549,12 @@ public partial class PieControl : UserControl
 
             slice.MouseLeave += (_, _) =>
             {
-                if (_interactionMode == InteractionMode.Mouse)
+                if (_drag?.Slice == sliceVisual)
+                {
+                    return;
+                }
+
+                if (_interactionMode == InteractionMode.Mouse && _drag == null)
                 {
                     ApplySliceNormalVisual(sliceVisual, animate: true);
                 }
@@ -541,10 +591,28 @@ public partial class PieControl : UserControl
             contentPanel.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
             var contentSize = contentPanel.DesiredSize;
 
-            Canvas.SetLeft(contentPanel, SnapToDevicePixel(textPosition.X - (contentSize.Width / 2), isXAxis: true));
-            Canvas.SetTop(contentPanel, SnapToDevicePixel(textPosition.Y - (contentSize.Height / 2), isXAxis: false));
+            var contentLeft = SnapToDevicePixel(textPosition.X - (contentSize.Width / 2), isXAxis: true);
+            var contentTop = SnapToDevicePixel(textPosition.Y - (contentSize.Height / 2), isXAxis: false);
+            Canvas.SetLeft(contentPanel, contentLeft);
+            Canvas.SetTop(contentPanel, contentTop);
 
-            Panel.SetZIndex(contentPanel, contentZIndex);
+            // Counter-rotate about the content's own center first, then orbit around the pie
+            // center, so the content follows its slice during reordering but stays upright.
+            var contentMargin = contentPanel.Margin;
+            var contentCounter = new RotateTransform(
+                0,
+                (contentSize.Width - contentMargin.Left - contentMargin.Right) / 2,
+                (contentSize.Height - contentMargin.Top - contentMargin.Bottom) / 2);
+            var contentOrbit = new RotateTransform(
+                0,
+                center.X - contentLeft - contentMargin.Left,
+                center.Y - contentTop - contentMargin.Top);
+            contentPanel.RenderTransform = new TransformGroup { Children = { contentCounter, contentOrbit } };
+            sliceVisual.ContentPanel = contentPanel;
+            sliceVisual.ContentCounter = contentCounter;
+            sliceVisual.ContentOrbit = contentOrbit;
+
+            Panel.SetZIndex(contentPanel, SliceContentZIndex);
             PieCanvas.Children.Add(contentPanel);
         }
 
@@ -566,6 +634,212 @@ public partial class PieControl : UserControl
         if (refreshVisualState)
         {
             RefreshVisualState(animate);
+        }
+    }
+
+    private void BeginDragTracking(PieSliceVisual sliceVisual, Point pressPosition)
+    {
+        if (_sliceVisuals.Count < 2)
+        {
+            _dragCandidate = null;
+            return;
+        }
+
+        _dragCandidate = sliceVisual;
+        _dragPressPosition = pressPosition;
+    }
+
+    private void HandleSliceMouseMove(PieSliceVisual sliceVisual, MouseEventArgs e)
+    {
+        if (_drag != null)
+        {
+            if (_drag.Slice == sliceVisual)
+            {
+                UpdateDrag(e.GetPosition(PieCanvas));
+            }
+
+            return;
+        }
+
+        if (_dragCandidate != sliceVisual || e.LeftButton != MouseButtonState.Pressed)
+        {
+            return;
+        }
+
+        var position = e.GetPosition(PieCanvas);
+        if (Math.Abs(position.X - _dragPressPosition.X) < SystemParameters.MinimumHorizontalDragDistance
+            && Math.Abs(position.Y - _dragPressPosition.Y) < SystemParameters.MinimumVerticalDragDistance)
+        {
+            return;
+        }
+
+        StartDrag(sliceVisual, position);
+    }
+
+    private void StartDrag(PieSliceVisual sliceVisual, Point position)
+    {
+        Log.Debug("Started dragging slice to reorder: {SliceName}", sliceVisual.Action.Name);
+
+        _drag = new DragReorderState
+        {
+            Slice = sliceVisual,
+            LastPointerAngle = PieReorderCalculator.GetPointerAngle(_layoutCenter, position),
+            RotationOffset = sliceVisual.RotationOffset,
+            TargetSlot = sliceVisual.CurrentSlot,
+        };
+
+        // Release any running reorder animations so the angle can be driven directly.
+        sliceVisual.PathRotation?.BeginAnimation(RotateTransform.AngleProperty, null);
+        sliceVisual.ContentOrbit?.BeginAnimation(RotateTransform.AngleProperty, null);
+        sliceVisual.ContentCounter?.BeginAnimation(RotateTransform.AngleProperty, null);
+
+        _animationService.AnimateClickUp(sliceVisual.Path, _renderState.PressDuration, _renderState.StandardEasing);
+        ApplySliceHoverVisual(sliceVisual, animate: true);
+        Panel.SetZIndex(sliceVisual.Path, DraggedSliceZIndex);
+        if (sliceVisual.ContentPanel != null)
+        {
+            Panel.SetZIndex(sliceVisual.ContentPanel, DraggedSliceContentZIndex);
+        }
+
+        sliceVisual.Path.CaptureMouse();
+    }
+
+    private void UpdateDrag(Point position)
+    {
+        var drag = _drag;
+        var pointerAngle = PieReorderCalculator.GetPointerAngle(_layoutCenter, position);
+        drag.RotationOffset += PieLayoutCalculator.NormalizeSignedAngle(pointerAngle - drag.LastPointerAngle);
+        drag.LastPointerAngle = pointerAngle;
+
+        SetSliceRotation(drag.Slice, drag.RotationOffset);
+
+        var targetSlot = PieReorderCalculator.GetTargetSlot(
+            drag.Slice.Index,
+            drag.RotationOffset,
+            _layoutAngleStep,
+            _sliceVisuals.Count);
+        if (targetSlot == drag.TargetSlot)
+        {
+            return;
+        }
+
+        drag.TargetSlot = targetSlot;
+        var slots = PieReorderCalculator.GetSlotAssignments(_sliceVisuals.Count, drag.Slice.Index, targetSlot);
+        foreach (var sliceVisual in _sliceVisuals)
+        {
+            if (sliceVisual == drag.Slice)
+            {
+                continue;
+            }
+
+            sliceVisual.CurrentSlot = slots[sliceVisual.Index];
+            var targetRotation = PieReorderCalculator.GetNearestEquivalentAngle(
+                sliceVisual.RotationOffset,
+                (sliceVisual.CurrentSlot - sliceVisual.Index) * _layoutAngleStep);
+            sliceVisual.RotationOffset = targetRotation;
+            AnimateSliceRotation(sliceVisual, targetRotation);
+        }
+    }
+
+    private bool EndDragTracking(PieSliceVisual sliceVisual)
+    {
+        _dragCandidate = null;
+
+        if (_drag?.Slice != sliceVisual)
+        {
+            return false;
+        }
+
+        var drag = _drag;
+        _drag = null;
+
+        _isReleasingDragCapture = true;
+        try
+        {
+            sliceVisual.Path.ReleaseMouseCapture();
+        }
+        finally
+        {
+            _isReleasingDragCapture = false;
+        }
+
+        sliceVisual.CurrentSlot = drag.TargetSlot;
+        var settledRotation = PieReorderCalculator.GetNearestEquivalentAngle(
+            drag.RotationOffset,
+            (drag.TargetSlot - sliceVisual.Index) * _layoutAngleStep);
+        sliceVisual.RotationOffset = settledRotation;
+        AnimateSliceRotation(sliceVisual, settledRotation, () => CommitReorder(sliceVisual, drag.TargetSlot));
+        return true;
+    }
+
+    private void CommitReorder(PieSliceVisual sliceVisual, int targetSlot)
+    {
+        if (targetSlot == sliceVisual.Index)
+        {
+            Log.Debug("Slice drag ended in its original slot: {SliceName}", sliceVisual.Action.Name);
+            if (sliceVisual.ContentPanel != null)
+            {
+                Panel.SetZIndex(sliceVisual.ContentPanel, SliceContentZIndex);
+            }
+
+            RefreshVisualState(animate: true);
+            return;
+        }
+
+        // Move the dragged action to the position of the action that was built at the target
+        // slot; disabled actions keep their relative placement in the collection.
+        var targetAction = _sliceVisuals.First(visual => visual.Index == targetSlot).Action;
+        var fromIndex = Slices.IndexOf(sliceVisual.Action);
+        var toIndex = Slices.IndexOf(targetAction);
+        if (fromIndex < 0 || toIndex < 0 || fromIndex == toIndex)
+        {
+            Log.Warning(
+                "Could not commit slice reorder (FromIndex={FromIndex}, ToIndex={ToIndex})",
+                fromIndex,
+                toIndex);
+            RequestRenderRefresh();
+            return;
+        }
+
+        Log.Information(
+            "Reordered slice by dragging: {SliceName} ({FromIndex} -> {ToIndex})",
+            sliceVisual.Action.Name,
+            fromIndex,
+            toIndex);
+        Slices.Move(fromIndex, toIndex);
+        SlicesReordered?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnSliceLostMouseCapture(PieSliceVisual sliceVisual)
+    {
+        if (_isReleasingDragCapture || _drag?.Slice != sliceVisual)
+        {
+            return;
+        }
+
+        Log.Debug("Slice drag canceled because mouse capture was lost: {SliceName}", sliceVisual.Action.Name);
+        _drag = null;
+        _dragCandidate = null;
+        RequestRenderRefresh();
+    }
+
+    private static void SetSliceRotation(PieSliceVisual sliceVisual, double angle)
+    {
+        sliceVisual.PathRotation.Angle = angle;
+        if (sliceVisual.ContentOrbit != null)
+        {
+            sliceVisual.ContentOrbit.Angle = angle;
+            sliceVisual.ContentCounter.Angle = -angle;
+        }
+    }
+
+    private void AnimateSliceRotation(PieSliceVisual sliceVisual, double toAngle, Action onCompleted = null)
+    {
+        _animationService.AnimateRotationAngle(sliceVisual.PathRotation, toAngle, ReorderDuration, _renderState.StandardEasing, onCompleted);
+        if (sliceVisual.ContentOrbit != null)
+        {
+            _animationService.AnimateRotationAngle(sliceVisual.ContentOrbit, toAngle, ReorderDuration, _renderState.StandardEasing);
+            _animationService.AnimateRotationAngle(sliceVisual.ContentCounter, -toAngle, ReorderDuration, _renderState.StandardEasing);
         }
     }
 
@@ -754,6 +1028,11 @@ public partial class PieControl : UserControl
     /// Occurs when a slice is clicked.
     /// </summary>
     public event EventHandler<SliceClickEventArgs> SliceClicked;
+
+    /// <summary>
+    /// Occurs after the <see cref="Slices"/> collection is reordered by dragging a slice.
+    /// </summary>
+    public event EventHandler SlicesReordered;
 
     /// <summary>
     /// Occurs when the center close target is clicked.

--- a/RadialActions/Pie/PieReorderCalculator.cs
+++ b/RadialActions/Pie/PieReorderCalculator.cs
@@ -1,0 +1,68 @@
+using System.Windows;
+
+namespace RadialActions;
+
+/// <summary>
+/// Pure math for drag-and-drop slice reordering.
+/// </summary>
+public static class PieReorderCalculator
+{
+    /// <summary>
+    /// Gets the angle of a point relative to the pie center, in degrees, using the same
+    /// convention as slice layout (0 = right, increasing clockwise).
+    /// </summary>
+    public static double GetPointerAngle(Point center, Point position)
+    {
+        return Math.Atan2(position.Y - center.Y, position.X - center.X) * 180 / Math.PI;
+    }
+
+    /// <summary>
+    /// Gets the slot a slice lands in after being rotated away from its original position.
+    /// </summary>
+    public static int GetTargetSlot(int originalIndex, double rotationOffset, double angleStep, int sliceCount)
+    {
+        var slotDelta = (int)Math.Round(rotationOffset / angleStep);
+        return Mod(originalIndex + slotDelta, sliceCount);
+    }
+
+    /// <summary>
+    /// Gets the angle equivalent to <paramref name="targetAngle"/> (mod 360) that is closest to
+    /// <paramref name="currentAngle"/>, so rotation animations take the short way around.
+    /// </summary>
+    public static double GetNearestEquivalentAngle(double currentAngle, double targetAngle)
+    {
+        return targetAngle + (360 * Math.Round((currentAngle - targetAngle) / 360));
+    }
+
+    /// <summary>
+    /// Assigns a slot to each slice while the dragged slice floats over <paramref name="targetSlot"/>.
+    /// The remaining slices keep their relative order and shift to fill the gap.
+    /// </summary>
+    /// <returns>An array mapping each slice's original index to its current slot.</returns>
+    public static int[] GetSlotAssignments(int sliceCount, int draggedIndex, int targetSlot)
+    {
+        var order = new List<int>(sliceCount);
+        for (var i = 0; i < sliceCount; i++)
+        {
+            if (i != draggedIndex)
+            {
+                order.Add(i);
+            }
+        }
+
+        order.Insert(targetSlot, draggedIndex);
+
+        var slots = new int[sliceCount];
+        for (var slot = 0; slot < order.Count; slot++)
+        {
+            slots[order[slot]] = slot;
+        }
+
+        return slots;
+    }
+
+    private static int Mod(int value, int modulus)
+    {
+        return ((value % modulus) + modulus) % modulus;
+    }
+}

--- a/RadialActions/Pie/PieSliceVisual.cs
+++ b/RadialActions/Pie/PieSliceVisual.cs
@@ -14,6 +14,33 @@ internal sealed class PieSliceVisual
     public required SolidColorBrush StrokeBrush { get; init; }
     public required ContextMenu ContextMenu { get; init; }
 
+    /// <summary>
+    /// Rotates the slice path around the pie center during drag reordering.
+    /// </summary>
+    public RotateTransform PathRotation { get; set; }
+
+    /// <summary>
+    /// Orbits the content panel around the pie center during drag reordering.
+    /// </summary>
+    public RotateTransform ContentOrbit { get; set; }
+
+    /// <summary>
+    /// Counter-rotates the content panel about its own center so it stays upright while orbiting.
+    /// </summary>
+    public RotateTransform ContentCounter { get; set; }
+
+    public StackPanel ContentPanel { get; set; }
+
+    /// <summary>
+    /// The slot this slice currently occupies; starts equal to <see cref="Index"/>.
+    /// </summary>
+    public int CurrentSlot { get; set; }
+
+    /// <summary>
+    /// The rotation in degrees this slice has settled at (or is animating toward) relative to its built position.
+    /// </summary>
+    public double RotationOffset { get; set; }
+
     public PieSelectionController.Item ToSelectionItem()
     {
         return new PieSelectionController.Item(Index, MidAngle);


### PR DESCRIPTION
Closes #45

## What changed

While the menu is open, you can now press and hold a slice and drag it around the ring to a new position. The other slices animate the short way around into their new slots as you cross slot boundaries, and dropping settles the slice into place and saves the new order immediately — no need to open the actions editor and use the Up/Down buttons.

- **`PieControl`** — pressing a slice arms a drag candidate; moving past the system drag threshold captures the mouse and rotates the slice (path + upright content) around the pie center to follow the pointer. A plain click is unchanged: `SliceClicked` still fires when released before the threshold. Losing mouse capture mid-drag (Esc, context menu, menu hidden) cancels cleanly and re-renders.
- **`PieReorderCalculator`** (new) — pure math for pointer angle, rotation→slot mapping, shortest-way-around angle equivalence, and slot assignments while a slice floats over a target slot.
- **Commit + persistence** — on drop, the dragged action is `Move`d within the bound `ObservableCollection<PieAction>` to the position of the action built at the target slot, so disabled actions keep their relative placement and the Settings editor list updates live. A new `SlicesReordered` event lets `MainWindow` save settings right away (they previously only saved when the Settings window closed).
- **`PieAnimationService`** — the press-scale animation now finds its `ScaleTransform` inside a `TransformGroup` so the press effect and the reorder rotation can coexist, plus a rotation animation helper that respects reduced motion.

## Notes for review

- Slice content stays upright while orbiting via a counter-rotation about its own center composed with an orbit around the pie center; both animate in sync.
- Reordering is skipped when fewer than 2 slices are enabled.
- New unit tests cover the reorder math (`PieReorderCalculatorTests`); full suite passes (87/87).
- Manual-testing focus: drag across the 12 o'clock wrap-around, drag with a disabled action in the list, and click-vs-drag disambiguation.

## Demo


https://github.com/user-attachments/assets/15ccfe31-59c8-4334-a144-978b1d0e0b49

