### PR TITLE
Add macro actions with a step-based editor

### DIFF
--- a/RadialActions.Tests/Actions/ActionEditorViewModelTests.cs
+++ b/RadialActions.Tests/Actions/ActionEditorViewModelTests.cs
@@ -1,0 +1,128 @@
+namespace RadialActions.Tests;
+
+public class ActionEditorViewModelTests
+{
+    private static ActionEditorViewModel CreateViewModel(out PieAction action)
+    {
+        action = new PieAction("Test action");
+        var viewModel = new ActionEditorViewModel(new ActionDefaultsService(), [action])
+        {
+            SelectedAction = action,
+        };
+        return viewModel;
+    }
+
+    [Fact]
+    public void SelectedActionType_SwitchToMacro_SeedsOneStepAndClearsShellFields()
+    {
+        var viewModel = CreateViewModel(out var action);
+        action.Parameter = "explorer.exe";
+        action.Arguments = "--foo";
+        action.WorkingDirectory = "C:\\";
+
+        viewModel.SelectedActionType = ActionType.Macro;
+
+        Assert.Equal(ActionType.Macro, action.Type);
+        Assert.Equal(string.Empty, action.Parameter);
+        Assert.Equal(string.Empty, action.Arguments);
+        Assert.Equal(string.Empty, action.WorkingDirectory);
+        Assert.Single(action.MacroSteps);
+    }
+
+    [Fact]
+    public void SelectedActionType_SwitchToNone_ClearsMacroSteps()
+    {
+        var viewModel = CreateViewModel(out var action);
+        viewModel.SelectedActionType = ActionType.Macro;
+        Assert.Single(action.MacroSteps);
+
+        viewModel.SelectedActionType = ActionType.None;
+
+        Assert.Empty(action.MacroSteps);
+    }
+
+    [Fact]
+    public void SelectingMacroAction_WithNoSteps_SeedsOneStep()
+    {
+        var action = new PieAction("Macro") { Type = ActionType.Macro };
+        var viewModel = new ActionEditorViewModel(new ActionDefaultsService(), [action])
+        {
+            SelectedAction = action,
+        };
+
+        Assert.Single(action.MacroSteps);
+    }
+
+    [Fact]
+    public void AddMacroStepCommand_AppendsStep()
+    {
+        var viewModel = CreateViewModel(out var action);
+        viewModel.SelectedActionType = ActionType.Macro;
+
+        viewModel.AddMacroStepCommand.Execute(null);
+
+        Assert.Equal(2, action.MacroSteps.Count);
+    }
+
+    [Fact]
+    public void RemoveMacroStepCommand_RemovesStep()
+    {
+        var viewModel = CreateViewModel(out var action);
+        viewModel.SelectedActionType = ActionType.Macro;
+        var step = action.MacroSteps[0];
+
+        viewModel.RemoveMacroStepCommand.Execute(step);
+
+        Assert.Empty(action.MacroSteps);
+    }
+
+    [Fact]
+    public void DuplicateMacroStepCommand_InsertsCopyAfterOriginal()
+    {
+        var viewModel = CreateViewModel(out var action);
+        viewModel.SelectedActionType = ActionType.Macro;
+        var step = action.MacroSteps[0];
+        step.Type = MacroStepType.Text;
+        step.Value = "hello";
+
+        viewModel.DuplicateMacroStepCommand.Execute(step);
+
+        Assert.Equal(2, action.MacroSteps.Count);
+        Assert.NotSame(step, action.MacroSteps[1]);
+        Assert.Equal(MacroStepType.Text, action.MacroSteps[1].Type);
+        Assert.Equal("hello", action.MacroSteps[1].Value);
+    }
+
+    [Fact]
+    public void MoveMacroStepCommands_ReorderSteps()
+    {
+        var viewModel = CreateViewModel(out var action);
+        viewModel.SelectedActionType = ActionType.Macro;
+        viewModel.AddMacroStepCommand.Execute(null);
+        var first = action.MacroSteps[0];
+        var second = action.MacroSteps[1];
+
+        viewModel.MoveMacroStepDownCommand.Execute(first);
+
+        Assert.Same(second, action.MacroSteps[0]);
+        Assert.Same(first, action.MacroSteps[1]);
+
+        viewModel.MoveMacroStepUpCommand.Execute(first);
+
+        Assert.Same(first, action.MacroSteps[0]);
+        Assert.Same(second, action.MacroSteps[1]);
+    }
+
+    [Fact]
+    public void MoveMacroStepCommands_AtBounds_DoNothing()
+    {
+        var viewModel = CreateViewModel(out var action);
+        viewModel.SelectedActionType = ActionType.Macro;
+        var step = action.MacroSteps[0];
+
+        viewModel.MoveMacroStepUpCommand.Execute(step);
+        viewModel.MoveMacroStepDownCommand.Execute(step);
+
+        Assert.Same(step, Assert.Single(action.MacroSteps));
+    }
+}

--- a/RadialActions.Tests/Actions/ActionsSettingsViewModelTests.cs
+++ b/RadialActions.Tests/Actions/ActionsSettingsViewModelTests.cs
@@ -72,7 +72,7 @@ public sealed class ActionsSettingsViewModelTests
     {
         var viewModel = new ActionEditorViewModel(new ActionDefaultsService(), []);
 
-        Assert.Equal([ActionType.Key, ActionType.Shell], viewModel.ActionTypes.Select(option => option.Type));
+        Assert.Equal([ActionType.Key, ActionType.Shell, ActionType.Macro], viewModel.ActionTypes.Select(option => option.Type));
     }
 
     [Fact]

--- a/RadialActions.Tests/Actions/MacroStepTests.cs
+++ b/RadialActions.Tests/Actions/MacroStepTests.cs
@@ -1,0 +1,150 @@
+namespace RadialActions.Tests;
+
+public class MacroStepTests
+{
+    [Fact]
+    public void GetValidationError_NullStep_ReturnsError()
+    {
+        Assert.NotNull(MacroStep.GetValidationError(null));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("DefinitelyNotAHotkey")]
+    public void GetValidationError_InvalidShortcut_ReturnsError(string value)
+    {
+        var step = new MacroStep { Type = MacroStepType.Shortcut, Value = value };
+
+        Assert.NotNull(MacroStep.GetValidationError(step));
+    }
+
+    [Theory]
+    [InlineData("Ctrl+C")]
+    [InlineData("Alt+Shift+F4")]
+    [InlineData("PlayPause")]
+    [InlineData("VolumeUp")]
+    public void GetValidationError_ValidShortcut_ReturnsNull(string value)
+    {
+        var step = new MacroStep { Type = MacroStepType.Shortcut, Value = value };
+
+        Assert.Null(MacroStep.GetValidationError(step));
+    }
+
+    [Fact]
+    public void GetValidationError_EmptyText_ReturnsError()
+    {
+        var step = new MacroStep { Type = MacroStepType.Text, Value = "" };
+
+        Assert.NotNull(MacroStep.GetValidationError(step));
+    }
+
+    [Fact]
+    public void GetValidationError_NonEmptyText_ReturnsNull()
+    {
+        var step = new MacroStep { Type = MacroStepType.Text, Value = "hello world" };
+
+        Assert.Null(MacroStep.GetValidationError(step));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(MacroStep.MaxDelayMilliseconds + 1)]
+    public void GetValidationError_OutOfRangeDelay_ReturnsError(int delay)
+    {
+        var step = new MacroStep { Type = MacroStepType.Delay, DelayMilliseconds = delay };
+
+        Assert.NotNull(MacroStep.GetValidationError(step));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(500)]
+    [InlineData(MacroStep.MaxDelayMilliseconds)]
+    public void GetValidationError_ValidDelay_ReturnsNull(int delay)
+    {
+        var step = new MacroStep { Type = MacroStepType.Delay, DelayMilliseconds = delay };
+
+        Assert.Null(MacroStep.GetValidationError(step));
+    }
+
+    [Fact]
+    public void GetValidationError_UndefinedType_ReturnsError()
+    {
+        var step = new MacroStep { Type = (MacroStepType)999 };
+
+        Assert.NotNull(MacroStep.GetValidationError(step));
+    }
+
+    [Fact]
+    public void NormalizeAfterLoad_RepairsInvalidValues()
+    {
+        var step = new MacroStep
+        {
+            Type = (MacroStepType)999,
+            Value = null,
+            DelayMilliseconds = -5,
+        };
+
+        step.NormalizeAfterLoad();
+
+        Assert.Equal(MacroStepType.Shortcut, step.Type);
+        Assert.Equal(string.Empty, step.Value);
+        Assert.Equal(MacroStep.DefaultDelayMilliseconds, step.DelayMilliseconds);
+    }
+
+    [Fact]
+    public void NormalizeAfterLoad_KeepsValidValues()
+    {
+        var step = new MacroStep
+        {
+            Type = MacroStepType.Delay,
+            Value = "unused",
+            DelayMilliseconds = 250,
+        };
+
+        step.NormalizeAfterLoad();
+
+        Assert.Equal(MacroStepType.Delay, step.Type);
+        Assert.Equal("unused", step.Value);
+        Assert.Equal(250, step.DelayMilliseconds);
+    }
+
+    [Fact]
+    public void Clone_CopiesAllFields()
+    {
+        var step = new MacroStep
+        {
+            Type = MacroStepType.Text,
+            Value = "hello",
+            DelayMilliseconds = 42,
+        };
+
+        var clone = step.Clone();
+
+        Assert.NotSame(step, clone);
+        Assert.Equal(step.Type, clone.Type);
+        Assert.Equal(step.Value, clone.Value);
+        Assert.Equal(step.DelayMilliseconds, clone.DelayMilliseconds);
+    }
+
+    [Fact]
+    public void ValidationError_UpdatesWhenPropertiesChange()
+    {
+        var step = new MacroStep { Type = MacroStepType.Shortcut, Value = "" };
+        var notified = false;
+        step.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(MacroStep.ValidationError))
+                notified = true;
+        };
+
+        Assert.NotNull(step.ValidationError);
+
+        step.Value = "Ctrl+C";
+
+        Assert.True(notified);
+        Assert.Null(step.ValidationError);
+    }
+}

--- a/RadialActions.Tests/Actions/PieActionTests.cs
+++ b/RadialActions.Tests/Actions/PieActionTests.cs
@@ -59,6 +59,39 @@ public class PieActionTests
     }
 
     [Fact]
+    public void Execute_MacroActionWithoutSteps_ThrowsInvalidOperationException()
+    {
+        var action = new PieAction("Macro") { Type = ActionType.Macro };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => action.Execute());
+
+        Assert.Equal("Macro has no steps", ex.Message);
+    }
+
+    [Fact]
+    public void Execute_MacroActionWithInvalidStep_ThrowsInvalidOperationException()
+    {
+        var action = new PieAction("Macro") { Type = ActionType.Macro };
+        action.MacroSteps.Add(new MacroStep { Type = MacroStepType.Delay, DelayMilliseconds = 100 });
+        action.MacroSteps.Add(new MacroStep { Type = MacroStepType.Shortcut, Value = "DefinitelyNotAHotkey" });
+
+        var ex = Assert.Throws<InvalidOperationException>(() => action.Execute());
+
+        Assert.StartsWith("Step 2:", ex.Message);
+    }
+
+    [Fact]
+    public void Execute_MacroActionWithNullStep_ThrowsInvalidOperationException()
+    {
+        var action = new PieAction("Macro") { Type = ActionType.Macro };
+        action.MacroSteps.Add(null);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => action.Execute());
+
+        Assert.StartsWith("Step 1:", ex.Message);
+    }
+
+    [Fact]
     public void Execute_KeyActionWithInvalidShortcut_ThrowsInvalidOperationException()
     {
         var action = new PieAction("Shortcut")

--- a/RadialActions.Tests/Settings/SettingsSerializationTests.cs
+++ b/RadialActions.Tests/Settings/SettingsSerializationTests.cs
@@ -89,6 +89,71 @@ public class SettingsSerializationTests
     }
 
     [Fact]
+    public void SerializeToJson_RoundTripsMacroSteps()
+    {
+        var settings = Settings.DeserializeFromJson("{}");
+        var macro = new PieAction("My Macro") { Type = ActionType.Macro };
+        macro.MacroSteps.Add(new MacroStep { Type = MacroStepType.Shortcut, Value = "Ctrl+C" });
+        macro.MacroSteps.Add(new MacroStep { Type = MacroStepType.Delay, DelayMilliseconds = 250 });
+        macro.MacroSteps.Add(new MacroStep { Type = MacroStepType.Text, Value = "hello" });
+        settings.Actions = [macro];
+
+        var json = settings.SerializeToJson();
+        var loaded = Settings.DeserializeFromJson(json);
+
+        var loadedMacro = Assert.Single(loaded.Actions);
+        Assert.Equal(ActionType.Macro, loadedMacro.Type);
+        Assert.Equal(3, loadedMacro.MacroSteps.Count);
+        Assert.Equal(MacroStepType.Shortcut, loadedMacro.MacroSteps[0].Type);
+        Assert.Equal("Ctrl+C", loadedMacro.MacroSteps[0].Value);
+        Assert.Equal(MacroStepType.Delay, loadedMacro.MacroSteps[1].Type);
+        Assert.Equal(250, loadedMacro.MacroSteps[1].DelayMilliseconds);
+        Assert.Equal(MacroStepType.Text, loadedMacro.MacroSteps[2].Type);
+        Assert.Equal("hello", loadedMacro.MacroSteps[2].Value);
+    }
+
+    [Fact]
+    public void DeserializeFromJson_NormalizesInvalidMacroSteps()
+    {
+        const string json = """
+        {
+          "Actions": [
+            {
+              "Name": "Macro",
+              "Type": 3,
+              "MacroSteps": [
+                null,
+                {
+                  "Type": 999,
+                  "Value": null,
+                  "DelayMilliseconds": -1
+                }
+              ]
+            },
+            {
+              "Name": "Old Action",
+              "Type": 1,
+              "Parameter": "Mute",
+              "MacroSteps": null
+            }
+          ]
+        }
+        """;
+
+        var settings = Settings.DeserializeFromJson(json);
+
+        Assert.Equal(2, settings.Actions.Count);
+
+        var macroStep = Assert.Single(settings.Actions[0].MacroSteps);
+        Assert.Equal(MacroStepType.Shortcut, macroStep.Type);
+        Assert.Equal(string.Empty, macroStep.Value);
+        Assert.Equal(MacroStep.DefaultDelayMilliseconds, macroStep.DelayMilliseconds);
+
+        Assert.NotNull(settings.Actions[1].MacroSteps);
+        Assert.Empty(settings.Actions[1].MacroSteps);
+    }
+
+    [Fact]
     public void DeserializeFromJson_MissingIsEnabled_DefaultsToTrue()
     {
         const string json = """

--- a/RadialActions/Actions/Action.cs
+++ b/RadialActions/Actions/Action.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.IO;
 using CommunityToolkit.Mvvm.ComponentModel;
 
@@ -23,6 +24,11 @@ public enum ActionType
     /// Launch an app, open a file, or open a URL using shell execution.
     /// </summary>
     Shell = 2,
+
+    /// <summary>
+    /// Run a sequence of macro steps such as shortcuts, typed text, and delays.
+    /// </summary>
+    Macro = 3,
 }
 
 /// <summary>
@@ -117,6 +123,12 @@ public partial class PieAction : ObservableObject
     private string _workingDirectory = string.Empty;
 
     /// <summary>
+    /// The ordered steps to run for macro actions.
+    /// </summary>
+    [ObservableProperty]
+    private ObservableCollection<MacroStep> _macroSteps = [];
+
+    /// <summary>
     /// Creates a new empty action.
     /// </summary>
     public PieAction() { }
@@ -176,6 +188,9 @@ public partial class PieAction : ObservableObject
             case ActionType.Shell:
                 ExecuteShell();
                 return;
+            case ActionType.Macro:
+                ExecuteMacro();
+                return;
             default:
                 throw new NotSupportedException("Action type is not supported");
         }
@@ -186,16 +201,71 @@ public partial class PieAction : ObservableObject
         if (string.IsNullOrWhiteSpace(Parameter))
             throw new InvalidOperationException("Shortcut not configured");
 
-        if (TryGetKeyAction(Parameter, out var definition))
+        if (!TryGetKeyAction(Parameter, out _) && !HotkeyUtil.TryParse(Parameter, out _, out _))
+            throw new InvalidOperationException("Shortcut is invalid");
+
+        SimulateConfiguredShortcut(Parameter);
+    }
+
+    /// <summary>
+    /// Simulates a predefined key action or a parsed keyboard shortcut. The value must already be validated.
+    /// </summary>
+    private static void SimulateConfiguredShortcut(string value)
+    {
+        if (TryGetKeyAction(value, out var definition))
         {
             ActionUtil.SimulateKey(definition.VirtualKey);
             return;
         }
 
-        if (!HotkeyUtil.TryParse(Parameter, out _, out _))
-            throw new InvalidOperationException("Shortcut is invalid");
+        ActionUtil.SimulateKeyboardShortcut(value);
+    }
 
-        ActionUtil.SimulateKeyboardShortcut(Parameter);
+    private void ExecuteMacro()
+    {
+        if (MacroSteps == null || MacroSteps.Count == 0)
+            throw new InvalidOperationException("Macro has no steps");
+
+        // Snapshot the steps so edits made while the macro runs can't change or break it mid-flight.
+        var steps = MacroSteps.Select(step => step?.Clone()).ToArray();
+
+        for (var i = 0; i < steps.Length; i++)
+        {
+            var error = MacroStep.GetValidationError(steps[i]);
+            if (error != null)
+                throw new InvalidOperationException($"Step {i + 1}: {error}");
+        }
+
+        // Run on a background thread so delay steps don't freeze the menu.
+        Task.Run(() => RunMacroSteps(Name, steps));
+    }
+
+    private static void RunMacroSteps(string macroName, MacroStep[] steps)
+    {
+        try
+        {
+            foreach (var step in steps)
+            {
+                switch (step.Type)
+                {
+                    case MacroStepType.Shortcut:
+                        SimulateConfiguredShortcut(step.Value);
+                        break;
+                    case MacroStepType.Text:
+                        ActionUtil.SimulateText(step.Value);
+                        break;
+                    case MacroStepType.Delay:
+                        Thread.Sleep(Math.Clamp(step.DelayMilliseconds, 1, MacroStep.MaxDelayMilliseconds));
+                        break;
+                }
+            }
+
+            Log.Information($"Macro finished: {macroName}");
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, $"Macro failed: {macroName}");
+        }
     }
 
     private void ExecuteShell()

--- a/RadialActions/Actions/ActionUtil.cs
+++ b/RadialActions/Actions/ActionUtil.cs
@@ -38,6 +38,10 @@ public static class ActionUtil
     private const uint INPUT_KEYBOARD = 1;
     private const uint KEYEVENTF_EXTENDEDKEY = 0x0001;
     private const uint KEYEVENTF_KEYUP = 0x0002;
+    private const uint KEYEVENTF_UNICODE = 0x0004;
+
+    private const byte VK_RETURN = 0x0D;
+    private const byte VK_TAB = 0x09;
 
     [DllImport("user32.dll", SetLastError = true)]
     private static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, IntPtr dwExtraInfo);
@@ -164,6 +168,63 @@ public static class ActionUtil
         var lParam = (IntPtr)(appCommand << 16);
         SendMessage(hwnd, WM_APPCOMMAND, hwnd, lParam);
         return true;
+    }
+
+    /// <summary>
+    /// Types a string of text into the focused window using Unicode keyboard input.
+    /// </summary>
+    /// <param name="text">The text to type. Newlines are sent as Enter and tabs as Tab.</param>
+    public static void SimulateText(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return;
+
+        foreach (var ch in text)
+        {
+            switch (ch)
+            {
+                case '\r':
+                    // Skip so "\r\n" produces a single Enter press.
+                    continue;
+                case '\n':
+                    SendKey(VK_RETURN, isKeyUp: false);
+                    SendKey(VK_RETURN, isKeyUp: true);
+                    continue;
+                case '\t':
+                    SendKey(VK_TAB, isKeyUp: false);
+                    SendKey(VK_TAB, isKeyUp: true);
+                    continue;
+                default:
+                    SendUnicodeChar(ch, isKeyUp: false);
+                    SendUnicodeChar(ch, isKeyUp: true);
+                    continue;
+            }
+        }
+    }
+
+    private static void SendUnicodeChar(char ch, bool isKeyUp)
+    {
+        var flags = KEYEVENTF_UNICODE;
+        if (isKeyUp)
+            flags |= KEYEVENTF_KEYUP;
+
+        var input = new INPUT
+        {
+            type = INPUT_KEYBOARD,
+            U = new InputUnion
+            {
+                ki = new KEYBDINPUT
+                {
+                    wVk = 0,
+                    wScan = ch,
+                    dwFlags = flags,
+                    time = 0,
+                    dwExtraInfo = IntPtr.Zero
+                }
+            }
+        };
+
+        SendInput(1, new[] { input }, Marshal.SizeOf<INPUT>());
     }
 
     /// <summary>

--- a/RadialActions/Actions/MacroStep.cs
+++ b/RadialActions/Actions/MacroStep.cs
@@ -1,0 +1,122 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Newtonsoft.Json;
+
+namespace RadialActions;
+
+/// <summary>
+/// Defines the kind of work a single macro step performs.
+/// </summary>
+public enum MacroStepType
+{
+    /// <summary>
+    /// Simulate a keyboard shortcut or a predefined key action.
+    /// </summary>
+    Shortcut = 0,
+
+    /// <summary>
+    /// Type a string of text into the focused window.
+    /// </summary>
+    Text = 1,
+
+    /// <summary>
+    /// Wait before running the next step.
+    /// </summary>
+    Delay = 2,
+}
+
+/// <summary>
+/// Represents a single step in a macro action.
+/// </summary>
+public partial class MacroStep : ObservableObject
+{
+    public const int DefaultDelayMilliseconds = 500;
+    public const int MaxDelayMilliseconds = 60_000;
+
+    /// <summary>
+    /// The kind of work this step performs.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ValidationError))]
+    private MacroStepType _type = MacroStepType.Shortcut;
+
+    /// <summary>
+    /// The shortcut (for example "Ctrl+C" or "PlayPause") or the text to type.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ValidationError))]
+    private string _value = string.Empty;
+
+    /// <summary>
+    /// How long a delay step waits, in milliseconds.
+    /// </summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ValidationError))]
+    private int _delayMilliseconds = DefaultDelayMilliseconds;
+
+    /// <summary>
+    /// A human-readable reason the step can't run, or <c>null</c> when the step is valid.
+    /// </summary>
+    [JsonIgnore]
+    public string ValidationError => GetValidationError(this);
+
+    /// <summary>
+    /// Returns why the step can't run, or <c>null</c> when the step is valid.
+    /// </summary>
+    public static string GetValidationError(MacroStep step)
+    {
+        if (step == null)
+        {
+            return "Step is missing";
+        }
+
+        switch (step.Type)
+        {
+            case MacroStepType.Shortcut:
+                if (string.IsNullOrWhiteSpace(step.Value))
+                    return "Enter a shortcut, such as Ctrl+C";
+                if (!PieAction.TryGetKeyAction(step.Value, out _) && !HotkeyUtil.TryParse(step.Value, out _, out _))
+                    return $"\"{step.Value}\" is not a valid shortcut";
+                return null;
+            case MacroStepType.Text:
+                if (string.IsNullOrEmpty(step.Value))
+                    return "Enter the text to type";
+                return null;
+            case MacroStepType.Delay:
+                if (step.DelayMilliseconds <= 0)
+                    return "Delay must be greater than zero";
+                if (step.DelayMilliseconds > MaxDelayMilliseconds)
+                    return $"Delay can't exceed {MaxDelayMilliseconds} milliseconds";
+                return null;
+            default:
+                return "Step type is not supported";
+        }
+    }
+
+    /// <summary>
+    /// Repairs missing or stale values loaded from an old or hand-edited settings file.
+    /// </summary>
+    public void NormalizeAfterLoad()
+    {
+        Value ??= string.Empty;
+
+        if (!Enum.IsDefined(typeof(MacroStepType), Type))
+        {
+            Type = MacroStepType.Shortcut;
+        }
+
+        if (DelayMilliseconds <= 0 || DelayMilliseconds > MaxDelayMilliseconds)
+        {
+            DelayMilliseconds = DefaultDelayMilliseconds;
+        }
+    }
+
+    /// <summary>
+    /// Creates a copy of this step.
+    /// </summary>
+    public MacroStep Clone() => new()
+    {
+        Type = Type,
+        Value = Value,
+        DelayMilliseconds = DelayMilliseconds,
+    };
+}

--- a/RadialActions/Properties/Settings.cs
+++ b/RadialActions/Properties/Settings.cs
@@ -73,6 +73,28 @@ public sealed partial class Settings
         ];
     }
 
+    private static void NormalizeMacroSteps(PieAction action)
+    {
+        if (action.MacroSteps == null)
+        {
+            action.MacroSteps = [];
+            return;
+        }
+
+        for (var i = action.MacroSteps.Count - 1; i >= 0; i--)
+        {
+            if (action.MacroSteps[i] == null)
+            {
+                action.MacroSteps.RemoveAt(i);
+            }
+        }
+
+        foreach (var step in action.MacroSteps)
+        {
+            step.NormalizeAfterLoad();
+        }
+    }
+
     internal void NormalizeAfterLoad()
     {
         ActivationHotkey ??= DefaultActivationHotkey;
@@ -107,6 +129,8 @@ public sealed partial class Settings
             {
                 action.Type = ActionType.None;
             }
+
+            NormalizeMacroSteps(action);
         }
     }
 }

--- a/RadialActions/Settings/ActionEditorView.xaml
+++ b/RadialActions/Settings/ActionEditorView.xaml
@@ -51,7 +51,7 @@
                 </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>
-        <TextBlock Text="Use Key for shortcuts and media controls; Shell for apps, files, folders, URLs, or commands."
+        <TextBlock Text="Use Key for shortcuts and media controls; Shell for apps, files, folders, URLs, or commands; Macro for a sequence of keystrokes, text, and delays."
                    Style="{StaticResource DescriptionTextBlock}" />
 
         <StackPanel Margin="0,0,0,4"
@@ -130,6 +130,150 @@
                         Padding="8,2" />
             </Grid>
             <TextBlock Text="Optional folder to use as the target's start location."
+                       Style="{StaticResource DescriptionTextBlock}" />
+        </StackPanel>
+
+        <StackPanel
+              Visibility="{Binding SelectedActionType, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionType.Macro}}">
+            <TextBlock Text="Steps:"
+                       Style="{StaticResource ActionEditorLabelTextBlock}" />
+            <ItemsControl ItemsSource="{Binding SelectedAction.MacroSteps}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <Border Margin="0,0,0,6"
+                                Padding="8"
+                                Background="{DynamicResource CardBackgroundFillColorDefaultBrush}"
+                                BorderBrush="{DynamicResource CardStrokeColorDefaultBrush}"
+                                BorderThickness="1"
+                                CornerRadius="6">
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="6" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="6" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+
+                                <ComboBox Grid.Row="0"
+                                          Grid.Column="0"
+                                          MinWidth="96"
+                                          VerticalAlignment="Center"
+                                          ItemsSource="{Binding DataContext.MacroStepTypes, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                          SelectedValue="{Binding Type, Mode=TwoWay}"
+                                          SelectedValuePath="Type">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="{Binding Icon}"
+                                                           Width="20"
+                                                           FontSize="14" />
+                                                <TextBlock Text="{Binding Name}"
+                                                           Margin="4,0,0,0"
+                                                           VerticalAlignment="Center" />
+                                            </StackPanel>
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
+
+                                <TextBox Grid.Row="0"
+                                         Grid.Column="2"
+                                         VerticalAlignment="Center"
+                                         Text="{Binding Value, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+                                    <TextBox.Style>
+                                        <Style TargetType="TextBox"
+                                               BasedOn="{StaticResource {x:Type TextBox}}">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding Type}"
+                                                             Value="Delay">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBox.Style>
+                                </TextBox>
+
+                                <Grid Grid.Row="0"
+                                      Grid.Column="2"
+                                      Visibility="{Binding Type, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:MacroStepType.Delay}}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="4" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBox Grid.Column="0"
+                                             VerticalAlignment="Center"
+                                             Text="{Binding DelayMilliseconds, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                    <TextBlock Grid.Column="2"
+                                               VerticalAlignment="Center"
+                                               Opacity="0.72"
+                                               Text="ms" />
+                                </Grid>
+
+                                <StackPanel Grid.Row="0"
+                                            Grid.Column="4"
+                                            Orientation="Horizontal"
+                                            VerticalAlignment="Center">
+                                    <Button Content="▲"
+                                            ToolTip="Move step up"
+                                            Padding="6,2"
+                                            Command="{Binding DataContext.MoveMacroStepUpCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                            CommandParameter="{Binding}" />
+                                    <Button Content="▼"
+                                            ToolTip="Move step down"
+                                            Margin="4,0,0,0"
+                                            Padding="6,2"
+                                            Command="{Binding DataContext.MoveMacroStepDownCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                            CommandParameter="{Binding}" />
+                                    <Button Content="⧉"
+                                            ToolTip="Duplicate step"
+                                            Margin="4,0,0,0"
+                                            Padding="6,2"
+                                            Command="{Binding DataContext.DuplicateMacroStepCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                            CommandParameter="{Binding}" />
+                                    <Button Content="✕"
+                                            ToolTip="Remove step"
+                                            Margin="4,0,0,0"
+                                            Padding="6,2"
+                                            Command="{Binding DataContext.RemoveMacroStepCommand, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                            CommandParameter="{Binding}" />
+                                </StackPanel>
+
+                                <TextBlock Grid.Row="1"
+                                           Grid.Column="0"
+                                           Grid.ColumnSpan="5"
+                                           Margin="0,4,0,0"
+                                           FontSize="12"
+                                           TextWrapping="Wrap"
+                                           Foreground="{DynamicResource SystemFillColorCriticalBrush}"
+                                           Text="{Binding ValidationError}">
+                                    <TextBlock.Style>
+                                        <Style TargetType="TextBlock"
+                                               BasedOn="{StaticResource {x:Type TextBlock}}">
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding ValidationError}"
+                                                             Value="{x:Null}">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </TextBlock.Style>
+                                </TextBlock>
+                            </Grid>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
+            <Button Content="Add Step"
+                    HorizontalAlignment="Left"
+                    Padding="8,2"
+                    Command="{Binding AddMacroStepCommand}" />
+            <TextBlock Text="Steps run in order. Keys sends a shortcut such as Ctrl+C or a media key like PlayPause; Text types into the focused window; Delay waits before the next step. Start with a short Delay if the target window needs time to regain focus."
                        Style="{StaticResource DescriptionTextBlock}" />
         </StackPanel>
     </StackPanel>

--- a/RadialActions/Settings/ActionEditorViewModel.cs
+++ b/RadialActions/Settings/ActionEditorViewModel.cs
@@ -30,6 +30,14 @@ public partial class ActionEditorViewModel : ObservableObject
     [
         new(ActionType.Key, "Key", "⌨️"),
         new(ActionType.Shell, "Shell", "🚀"),
+        new(ActionType.Macro, "Macro", "🎬"),
+    ];
+
+    public IReadOnlyList<MacroStepTypeOption> MacroStepTypes { get; } =
+    [
+        new(MacroStepType.Shortcut, "Keys", "⌨️"),
+        new(MacroStepType.Text, "Text", "🔤"),
+        new(MacroStepType.Delay, "Delay", "⏱️"),
     ];
 
     public IReadOnlyList<KeyActionDefinition> KeyActionOptions { get; } =
@@ -51,6 +59,7 @@ public partial class ActionEditorViewModel : ObservableObject
                 SelectedAction.Parameter = string.Empty;
                 SelectedAction.Arguments = string.Empty;
                 SelectedAction.WorkingDirectory = string.Empty;
+                SelectedAction.MacroSteps?.Clear();
             }
             else if (value == ActionType.Key)
             {
@@ -59,6 +68,13 @@ public partial class ActionEditorViewModel : ObservableObject
             else if (value == ActionType.Shell)
             {
                 SelectedAction.Parameter = string.Empty;
+            }
+            else if (value == ActionType.Macro)
+            {
+                SelectedAction.Parameter = string.Empty;
+                SelectedAction.Arguments = string.Empty;
+                SelectedAction.WorkingDirectory = string.Empty;
+                EnsureMacroSteps(SelectedAction);
             }
 
             OnPropertyChanged();
@@ -107,6 +123,80 @@ public partial class ActionEditorViewModel : ObservableObject
     public void Forget(PieAction action)
     {
         _actionDefaultsService.Forget(action);
+    }
+
+    /// <summary>
+    /// Makes sure a macro action has a steps collection and at least one step to edit.
+    /// </summary>
+    private static void EnsureMacroSteps(PieAction action)
+    {
+        action.MacroSteps ??= [];
+
+        if (action.MacroSteps.Count == 0)
+        {
+            action.MacroSteps.Add(new MacroStep());
+        }
+    }
+
+    [RelayCommand]
+    private void AddMacroStep()
+    {
+        if (SelectedAction == null)
+            return;
+
+        SelectedAction.MacroSteps ??= [];
+        SelectedAction.MacroSteps.Add(new MacroStep());
+    }
+
+    [RelayCommand]
+    private void RemoveMacroStep(MacroStep step)
+    {
+        if (step == null)
+            return;
+
+        SelectedAction?.MacroSteps?.Remove(step);
+    }
+
+    [RelayCommand]
+    private void DuplicateMacroStep(MacroStep step)
+    {
+        var steps = SelectedAction?.MacroSteps;
+        if (step == null || steps == null)
+            return;
+
+        var index = steps.IndexOf(step);
+        if (index < 0)
+            return;
+
+        steps.Insert(index + 1, step.Clone());
+    }
+
+    [RelayCommand]
+    private void MoveMacroStepUp(MacroStep step)
+    {
+        var steps = SelectedAction?.MacroSteps;
+        if (step == null || steps == null)
+            return;
+
+        var index = steps.IndexOf(step);
+        if (index <= 0)
+            return;
+
+        steps.Move(index, index - 1);
+    }
+
+    [RelayCommand]
+    private void MoveMacroStepDown(MacroStep step)
+    {
+        var steps = SelectedAction?.MacroSteps;
+        if (step == null || steps == null)
+            return;
+
+        var index = steps.IndexOf(step);
+        if (index < 0 || index >= steps.Count - 1)
+            return;
+
+        steps.Move(index, index + 1);
     }
 
     [RelayCommand]
@@ -166,6 +256,11 @@ public partial class ActionEditorViewModel : ObservableObject
         {
             newValue.PropertyChanged += SelectedActionPropertyChanged;
             _actionDefaultsService.EnsureKeyDefaults(newValue);
+
+            if (newValue.Type == ActionType.Macro)
+            {
+                EnsureMacroSteps(newValue);
+            }
         }
 
         OnPropertyChanged(nameof(SelectedActionType));
@@ -210,6 +305,20 @@ public sealed class ActionTypeOption
     }
 
     public ActionType Type { get; }
+    public string Name { get; }
+    public string Icon { get; }
+}
+
+public sealed class MacroStepTypeOption
+{
+    public MacroStepTypeOption(MacroStepType type, string name, string icon)
+    {
+        Type = type;
+        Name = name;
+        Icon = icon;
+    }
+
+    public MacroStepType Type { get; }
     public string Name { get; }
     public string Icon { get; }
 }


### PR DESCRIPTION
## Summary

Adds a third action type, **Macro**, that runs an ordered sequence of steps, plus a full step editor in the settings window. This lets a single pie slice perform multi-step automations like "focus delay → Ctrl+C → switch window → paste text".

Step kinds:
- **Keys** — a keyboard shortcut (`Ctrl+C`) or built-in media key (`PlayPause`), reusing the existing hotkey parser and key simulation.
- **Text** — a string typed into the focused window via Unicode `SendInput` (newlines map to Enter, tabs to Tab).
- **Delay** — a wait of 1 ms–60 s before the next step.

## Design choices

- **Validation before execution:** `Execute()` validates every step synchronously and throws with a step-numbered message, so misconfigured macros surface through the existing tray "Action failed" notification. Only after validation do the steps run on a background thread, so delay steps never freeze the menu (per the invariant that menu display stays fast).
- **Steps are snapshotted (cloned) before running,** so edits made while a macro is in flight can't corrupt it.
- **Editor follows the existing `ActionEditorView` pattern:** each step is a card with a type dropdown, a value editor that swaps to a millisecond field for delays, move up/down/duplicate/remove buttons, and an inline validation message driven by the step's `ValidationError` property.
- **Persistence:** steps serialize with the existing JSON settings; `NormalizeAfterLoad` repairs null collections, null items, out-of-range enum values, and invalid delays, keeping the safe-defaults invariant for hand-edited or stale files.

## Validation

- `dotnet build RadialActions.sln` — clean, 0 warnings.
- `dotnet test RadialActions.sln` — 121/121 pass (~30 new tests covering step validation, serialization round-trips, corrupt-settings normalization, macro execution guards, and all editor commands; one existing test updated for the new type option).
- Ran a throwaway WPF harness that loads the real `ActionEditorView` with a macro action, exercises every step command and type switch, and renders the view — no runtime XAML errors and the layout looks correct.

## Risks / notes

- No user-configured action runs during tests; macro tests only exercise validation failures.
- The validation message color uses `SystemFillColorCriticalBrush` from the Fluent theme; on themes without it the text falls back to the default foreground (message still shows).
- Focus timing is on the user: keystrokes go to whichever window is focused after the menu hides. The editor's description suggests starting with a short Delay when the target window needs time to regain focus.

## Follow-up ideas

Not included to keep the change reviewable: per-macro repeat counts, a macro recorder, and richer step kinds (e.g. mouse input). Worth revisiting if users ask for them.

## Screenshots

<img width="1800" height="1500" alt="image" src="https://github.com/user-attachments/assets/42bb77e3-5ccd-4053-b6e9-9cabf322c681" />
