### PR TITLE
Update "More from the Author" section

### DIFF
--- a/RadialActions/Settings/HelpSettingsView.xaml
+++ b/RadialActions/Settings/HelpSettingsView.xaml
@@ -96,24 +96,10 @@
                                  Margin="0,4,0,0">
                         <StackPanel Style="{StaticResource ProjectTileStackPanel}">
                             <TextBlock Style="{StaticResource ProjectTitleTextBlock}">
-                                <Hyperlink NavigateUri="https://github.com/danielchalmers/JournalApp">Good Diary</Hyperlink>
-                            </TextBlock>
-                            <TextBlock Style="{StaticResource ProjectDescriptionTextBlock}"
-                                       Text="Track your daily activities and moods on Android." />
-                        </StackPanel>
-                        <StackPanel Style="{StaticResource ProjectTileStackPanel}">
-                            <TextBlock Style="{StaticResource ProjectTitleTextBlock}">
                                 <Hyperlink NavigateUri="https://github.com/danielchalmers/DesktopClock">DesktopClock</Hyperlink>
                             </TextBlock>
                             <TextBlock Style="{StaticResource ProjectDescriptionTextBlock}"
                                        Text="A digital clock for your desktop." />
-                        </StackPanel>
-                        <StackPanel Style="{StaticResource ProjectTileStackPanel}">
-                            <TextBlock Style="{StaticResource ProjectTitleTextBlock}">
-                                <Hyperlink NavigateUri="https://github.com/danielchalmers/SentryReplay">Sentry Replay</Hyperlink>
-                            </TextBlock>
-                            <TextBlock Style="{StaticResource ProjectDescriptionTextBlock}"
-                                       Text="Review Tesla dashcam clips on Windows." />
                         </StackPanel>
                         <StackPanel Style="{StaticResource ProjectTileStackPanel}">
                             <TextBlock Style="{StaticResource ProjectTitleTextBlock}">
@@ -131,10 +117,38 @@
                         </StackPanel>
                         <StackPanel Style="{StaticResource ProjectTileStackPanel}">
                             <TextBlock Style="{StaticResource ProjectTitleTextBlock}">
+                                <Hyperlink NavigateUri="https://github.com/danielchalmers/JournalApp">Good Diary</Hyperlink>
+                            </TextBlock>
+                            <TextBlock Style="{StaticResource ProjectDescriptionTextBlock}"
+                                       Text="Track your daily activities and moods on Android." />
+                        </StackPanel>
+                        <StackPanel Style="{StaticResource ProjectTileStackPanel}">
+                            <TextBlock Style="{StaticResource ProjectTitleTextBlock}">
+                                <Hyperlink NavigateUri="https://github.com/danielchalmers/SentryReplay">Sentry Replay</Hyperlink>
+                            </TextBlock>
+                            <TextBlock Style="{StaticResource ProjectDescriptionTextBlock}"
+                                       Text="Review Tesla dashcam clips on Windows." />
+                        </StackPanel>
+                        <StackPanel Style="{StaticResource ProjectTileStackPanel}">
+                            <TextBlock Style="{StaticResource ProjectTitleTextBlock}">
                                 <Hyperlink NavigateUri="https://github.com/danielchalmers/Teichos">Teichos</Hyperlink>
                             </TextBlock>
                             <TextBlock Style="{StaticResource ProjectDescriptionTextBlock}"
                                        Text="Stay focused with URL blocking and schedules." />
+                        </StackPanel>
+                        <StackPanel Style="{StaticResource ProjectTileStackPanel}">
+                            <TextBlock Style="{StaticResource ProjectTitleTextBlock}">
+                                <Hyperlink NavigateUri="https://github.com/danielchalmers/Dayboard">Dayboard</Hyperlink>
+                            </TextBlock>
+                            <TextBlock Style="{StaticResource ProjectDescriptionTextBlock}"
+                                       Text="Put widgets on your browser's new tab page." />
+                        </StackPanel>
+                        <StackPanel Style="{StaticResource ProjectTileStackPanel}">
+                            <TextBlock Style="{StaticResource ProjectTitleTextBlock}">
+                                <Hyperlink NavigateUri="https://github.com/danielchalmers/NullTab">NullTab</Hyperlink>
+                            </TextBlock>
+                            <TextBlock Style="{StaticResource ProjectDescriptionTextBlock}"
+                                       Text="Replace your new tab page with a blank one." />
                         </StackPanel>
                     </UniformGrid>
                     <TextBlock Margin="0,0,0,8">


### PR DESCRIPTION
Refreshes the **More from the Author** panel in the Help settings tab, using the current project list from GitHub.

## Changes
- Expanded from **6 → 8 tiles** (clean 4×2 grid), reordered by prominence — DesktopClock (the flagship, 237★) now leads.
- **Added:** Dayboard, NullTab.
- **Refreshed taglines** across the set for a consistent, benefit-first voice.
- Excluded dev-tooling repos (Nuntia, AutoTriage) to keep the list focused on end-user apps, plus forks/archived repos and RadialActions itself.

## Final tiles
| Project | Tagline |
|---|---|
| DesktopClock | A digital clock for your desktop. |
| SteamAccountSwitcher | Swap Steam accounts from the system tray. |
| Network Monitor | Live latency and bandwidth in a desktop widget. |
| Good Diary | Track your daily activities and moods on Android. |
| Sentry Replay | Review Tesla dashcam clips on Windows. |
| Teichos | Stay focused with URL blocking and schedules. |
| Dayboard | Put widgets on your browser's new tab page. |
| NullTab | Replace your new tab page with a blank one. |

Only `RadialActions/Settings/HelpSettingsView.xaml` is touched.

<img width="1186" height="793" alt="image" src="https://github.com/user-attachments/assets/3a6a2323-eea1-484c-820c-c918645da278" />
