### PR TITLE
Create actions by dragging files, apps, and links onto the list

### DIFF
--- a/RadialActions.Tests/Actions/ActionDropFactoryTests.cs
+++ b/RadialActions.Tests/Actions/ActionDropFactoryTests.cs
@@ -1,0 +1,243 @@
+﻿using System.IO;
+using System.Text;
+using System.Windows;
+
+namespace RadialActions.Tests;
+
+public sealed class ActionDropFactoryTests : IDisposable
+{
+    private const string UniformResourceLocatorW = "UniformResourceLocatorW";
+    private const string UniformResourceLocator = "UniformResourceLocator";
+    private const string MozillaUrl = "text/x-moz-url";
+
+    private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "RadialActions.Tests", Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public void ExtractTargets_NullData_ReturnsEmpty()
+    {
+        Assert.Empty(ActionDropFactory.ExtractTargets(null));
+    }
+
+    [Fact]
+    public void ExtractTargets_EmptyData_ReturnsEmpty()
+    {
+        Assert.Empty(ActionDropFactory.ExtractTargets(new FakeDataObject()));
+    }
+
+    [Fact]
+    public void ExtractTargets_FileDrop_ReturnsPathsInOrder()
+    {
+        var data = new FakeDataObject().Set(DataFormats.FileDrop, new[] { @"C:\Apps\First.exe", @"C:\Docs\Second.txt" });
+
+        Assert.Equal([@"C:\Apps\First.exe", @"C:\Docs\Second.txt"], ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Fact]
+    public void ExtractTargets_FileDrop_DeduplicatesIgnoringCase()
+    {
+        var data = new FakeDataObject().Set(DataFormats.FileDrop, new[] { @"C:\Apps\First.exe", @"c:\apps\first.exe" });
+
+        Assert.Equal([@"C:\Apps\First.exe"], ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Fact]
+    public void ExtractTargets_PrefersFileDropOverText()
+    {
+        var data = new FakeDataObject()
+            .Set(DataFormats.FileDrop, new[] { @"C:\Apps\First.exe" })
+            .Set(DataFormats.UnicodeText, "https://example.com");
+
+        Assert.Equal([@"C:\Apps\First.exe"], ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Fact]
+    public void ExtractTargets_UnicodeTextUrl_ReturnsUrl()
+    {
+        var data = new FakeDataObject().Set(DataFormats.UnicodeText, "https://example.com/path");
+
+        Assert.Equal(["https://example.com/path"], ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Fact]
+    public void ExtractTargets_UniformResourceLocatorStream_DecodesNullTerminatedUrl()
+    {
+        var bytes = Encoding.Unicode.GetBytes("https://example.com\0");
+        var data = new FakeDataObject().Set(UniformResourceLocatorW, new MemoryStream(bytes));
+
+        Assert.Equal(["https://example.com"], ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Fact]
+    public void ExtractTargets_MozillaUrl_KeepsUrlLineOnly()
+    {
+        var bytes = Encoding.Unicode.GetBytes("https://example.com/\r\nExample Title");
+        var data = new FakeDataObject().Set(MozillaUrl, new MemoryStream(bytes));
+
+        Assert.Equal(["https://example.com/"], ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Fact]
+    public void ExtractTargets_PlainText_IsIgnored()
+    {
+        var data = new FakeDataObject().Set(DataFormats.UnicodeText, "just some dragged words");
+
+        Assert.Empty(ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Theory]
+    [InlineData("Re: Meeting notes")]
+    [InlineData("TODO: fix the drag handler")]
+    [InlineData("Note: call John tomorrow")]
+    [InlineData("std::string")]
+    public void ExtractTargets_SchemeLikeProse_IsIgnored(string text)
+    {
+        var data = new FakeDataObject().Set(DataFormats.UnicodeText, text);
+
+        Assert.Empty(ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Theory]
+    [InlineData("https://example.com")]
+    [InlineData("http://example.com/path")]
+    [InlineData("ftp://host/file.zip")]
+    [InlineData("mailto:user@example.com")]
+    public void ExtractTargets_LaunchableSchemes_AreAccepted(string url)
+    {
+        var data = new FakeDataObject().Set(DataFormats.UnicodeText, url);
+
+        Assert.Equal([url], ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Fact]
+    public void ExtractTargets_TextFallback_ReturnsUrl()
+    {
+        var data = new FakeDataObject().Set(DataFormats.Text, "https://example.com/path");
+
+        Assert.Equal(["https://example.com/path"], ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Fact]
+    public void ExtractTargets_AnsiUniformResourceLocatorStream_ReturnsUrl()
+    {
+        var bytes = Encoding.Latin1.GetBytes("https://example.com\0");
+        var data = new FakeDataObject().Set(UniformResourceLocator, new MemoryStream(bytes));
+
+        Assert.Equal(["https://example.com"], ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Fact]
+    public void ExtractTargets_PrefersDedicatedUrlFormatOverText()
+    {
+        var canonical = Encoding.Unicode.GetBytes("https://canonical.com\0");
+        var data = new FakeDataObject()
+            .Set(UniformResourceLocatorW, new MemoryStream(canonical))
+            .Set(DataFormats.UnicodeText, "https://fallback.com");
+
+        Assert.Equal(["https://canonical.com"], ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Fact]
+    public void ExtractTargets_WhitespaceOnlyText_ReturnsEmpty()
+    {
+        var data = new FakeDataObject().Set(DataFormats.UnicodeText, "   \r\n");
+
+        Assert.Empty(ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Fact]
+    public void ExtractTargets_FileDrop_SkipsEmptyEntries()
+    {
+        var data = new FakeDataObject().Set(DataFormats.FileDrop, new[] { "", "   ", @"C:\Apps\First.exe" });
+
+        Assert.Equal([@"C:\Apps\First.exe"], ActionDropFactory.ExtractTargets(data));
+    }
+
+    [Fact]
+    public void CreateAction_BlankTarget_UsesDefaultNameAndFileIcon()
+    {
+        var action = ActionDropFactory.CreateAction(string.Empty);
+
+        Assert.Equal(ActionType.Shell, action.Type);
+        Assert.Equal(PieAction.DefaultName, action.Name);
+        Assert.Equal(ShellActionDefaults.FileIcon, action.Icon);
+    }
+
+    [Fact]
+    public void CreateAction_Url_FillsWebDefaults()
+    {
+        var action = ActionDropFactory.CreateAction("https://example.com/path");
+
+        Assert.Equal(ActionType.Shell, action.Type);
+        Assert.Equal("https://example.com/path", action.Parameter);
+        Assert.Equal("example.com", action.Name);
+        Assert.Equal(ShellActionDefaults.WebIcon, action.Icon);
+        Assert.Equal(string.Empty, action.WorkingDirectory);
+    }
+
+    [Fact]
+    public void CreateAction_Directory_FillsFolderDefaults()
+    {
+        Directory.CreateDirectory(_tempRoot);
+        var folder = Path.Combine(_tempRoot, "Games");
+        Directory.CreateDirectory(folder);
+
+        var action = ActionDropFactory.CreateAction(folder);
+
+        Assert.Equal(ActionType.Shell, action.Type);
+        Assert.Equal(folder, action.Parameter);
+        Assert.Equal("Games", action.Name);
+        Assert.Equal(ShellActionDefaults.FolderIcon, action.Icon);
+        Assert.Equal(folder, action.WorkingDirectory);
+    }
+
+    [Fact]
+    public void CreateAction_File_FillsFileDefaults()
+    {
+        Directory.CreateDirectory(_tempRoot);
+        var file = Path.Combine(_tempRoot, "Notes.txt");
+        File.WriteAllText(file, string.Empty);
+
+        var action = ActionDropFactory.CreateAction(file);
+
+        Assert.Equal(ActionType.Shell, action.Type);
+        Assert.Equal(file, action.Parameter);
+        Assert.Equal("Notes", action.Name);
+        Assert.Equal(ShellActionDefaults.FileIcon, action.Icon);
+        Assert.Equal(_tempRoot, action.WorkingDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempRoot))
+        {
+            Directory.Delete(_tempRoot, recursive: true);
+        }
+    }
+
+    private sealed class FakeDataObject : IDataObject
+    {
+        private readonly Dictionary<string, object> _data = new(StringComparer.Ordinal);
+
+        public FakeDataObject Set(string format, object value)
+        {
+            _data[format] = value;
+            return this;
+        }
+
+        public object GetData(string format) => _data.TryGetValue(format, out var value) ? value : null;
+        public object GetData(string format, bool autoConvert) => GetData(format);
+        public object GetData(Type format) => GetData(format.FullName);
+
+        public bool GetDataPresent(string format) => _data.ContainsKey(format);
+        public bool GetDataPresent(string format, bool autoConvert) => GetDataPresent(format);
+        public bool GetDataPresent(Type format) => GetDataPresent(format.FullName);
+
+        public string[] GetFormats() => [.. _data.Keys];
+        public string[] GetFormats(bool autoConvert) => GetFormats();
+
+        public void SetData(object data) => throw new NotSupportedException();
+        public void SetData(string format, object data) => Set(format, data);
+        public void SetData(Type format, object data) => throw new NotSupportedException();
+        public void SetData(string format, object data, bool autoConvert) => Set(format, data);
+    }
+}

--- a/RadialActions.Tests/Actions/ActionsSettingsViewModelTests.cs
+++ b/RadialActions.Tests/Actions/ActionsSettingsViewModelTests.cs
@@ -68,6 +68,55 @@ public sealed class ActionsSettingsViewModelTests
     }
 
     [Fact]
+    public void AddDroppedTargets_InsertsAfterSelectionAndSelectsLast()
+    {
+        var first = PieAction.CreateKeyAction("Mute");
+        var second = PieAction.CreateKeyAction("VolumeUp");
+        var third = PieAction.CreateKeyAction("VolumeDown");
+        var viewModel = CreateViewModel(first, second, third);
+        viewModel.SelectAction(second);
+
+        viewModel.AddDroppedTargets(["https://a.com", "https://b.com"]);
+
+        var addedA = viewModel.Actions[2];
+        var addedB = viewModel.Actions[3];
+        Assert.Equal([first, second, addedA, addedB, third], viewModel.Actions);
+        Assert.Equal(ActionType.Shell, addedA.Type);
+        Assert.Equal("https://a.com", addedA.Parameter);
+        Assert.Equal("https://b.com", addedB.Parameter);
+        Assert.Same(addedB, viewModel.SelectedAction);
+        Assert.Equal(3, viewModel.SelectedActionIndex);
+        Assert.Same(addedB, viewModel.Editor.SelectedAction);
+    }
+
+    [Fact]
+    public void AddDroppedTargets_WithoutSelection_AppendsAtEnd()
+    {
+        var viewModel = CreateViewModel();
+
+        viewModel.AddDroppedTargets(["https://a.com"]);
+
+        var added = Assert.Single(viewModel.Actions);
+        Assert.Equal("https://a.com", added.Parameter);
+        Assert.Same(added, viewModel.SelectedAction);
+        Assert.Equal(0, viewModel.SelectedActionIndex);
+    }
+
+    [Fact]
+    public void AddDroppedTargets_EmptyOrNull_DoesNothing()
+    {
+        var first = PieAction.CreateKeyAction("Mute");
+        var viewModel = CreateViewModel(first);
+
+        viewModel.AddDroppedTargets([]);
+        viewModel.AddDroppedTargets(null);
+
+        Assert.Equal([first], viewModel.Actions);
+        Assert.Same(first, viewModel.SelectedAction);
+        Assert.Equal(0, viewModel.SelectedActionIndex);
+    }
+
+    [Fact]
     public void ActionEditorViewModel_ActionTypes_HidesNoneType()
     {
         var viewModel = new ActionEditorViewModel(new ActionDefaultsService(), []);

--- a/RadialActions/Actions/ActionDropFactory.cs
+++ b/RadialActions/Actions/ActionDropFactory.cs
@@ -1,0 +1,141 @@
+﻿using System.IO;
+using System.Text;
+using System.Windows;
+
+namespace RadialActions;
+
+/// <summary>
+/// Turns data dropped onto the actions list (files, folders, apps, or links) into prefilled shell actions.
+/// </summary>
+public static class ActionDropFactory
+{
+    // OLE formats browsers use to advertise a dragged link; these are not exposed by DataFormats.
+    private const string UniformResourceLocatorW = "UniformResourceLocatorW";
+    private const string UniformResourceLocator = "UniformResourceLocator";
+    private const string MozillaUrl = "text/x-moz-url";
+
+    /// <summary>
+    /// Extracts the ordered, de-duplicated launch targets (file/folder paths or URLs) carried by a drop, or an empty list if there are none.
+    /// </summary>
+    public static IReadOnlyList<string> ExtractTargets(IDataObject data)
+    {
+        if (data == null)
+            return [];
+
+        var targets = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void Add(string candidate)
+        {
+            var trimmed = candidate?.Trim();
+            if (!string.IsNullOrEmpty(trimmed) && seen.Add(trimmed))
+            {
+                targets.Add(trimmed);
+            }
+        }
+
+        // Files, folders, and shortcuts dragged from Explorer or the desktop.
+        if (data.GetDataPresent(DataFormats.FileDrop) && data.GetData(DataFormats.FileDrop) is string[] paths)
+        {
+            foreach (var path in paths)
+            {
+                Add(path);
+            }
+        }
+
+        // A link dragged from a browser or editor; only accept it when nothing more specific was dropped.
+        if (targets.Count == 0)
+        {
+            var url = ReadUrl(data);
+            if (LooksLikeTarget(url))
+            {
+                Add(url);
+            }
+        }
+
+        return targets;
+    }
+
+    /// <summary>
+    /// Builds a shell action for a single dropped target, prefilling its name, icon, and working directory from <see cref="ShellActionDefaults"/>.
+    /// </summary>
+    public static PieAction CreateAction(string target)
+    {
+        var defaults = ShellActionDefaults.FromTarget(target)
+            ?? new ShellActionDefaults(PieAction.DefaultName, ShellActionDefaults.FileIcon, string.Empty);
+
+        return PieAction.CreateShellAction(defaults.Name, target, defaults.Icon, workingDirectory: defaults.WorkingDirectory);
+    }
+
+    // Reads the most specific link text the drop advertises, preferring the dedicated URL formats over plain text.
+    private static string ReadUrl(IDataObject data)
+    {
+        if (TryReadText(data, UniformResourceLocatorW, Encoding.Unicode, out var unicodeUrl))
+            return unicodeUrl;
+
+        if (TryReadText(data, UniformResourceLocator, Encoding.Latin1, out var ansiUrl))
+            return ansiUrl;
+
+        // Firefox advertises "URL\nTitle"; keep only the URL.
+        if (TryReadText(data, MozillaUrl, Encoding.Unicode, out var mozUrl))
+            return FirstLine(mozUrl);
+
+        if (data.GetDataPresent(DataFormats.UnicodeText) && data.GetData(DataFormats.UnicodeText) is string unicodeText)
+            return FirstLine(unicodeText);
+
+        if (data.GetDataPresent(DataFormats.Text) && data.GetData(DataFormats.Text) is string text)
+            return FirstLine(text);
+
+        return string.Empty;
+    }
+
+    // Reads a custom clipboard format that may arrive as a string or a null-terminated byte stream.
+    private static bool TryReadText(IDataObject data, string format, Encoding encoding, out string value)
+    {
+        value = string.Empty;
+
+        if (!data.GetDataPresent(format))
+            return false;
+
+        value = data.GetData(format) switch
+        {
+            string s => s,
+            MemoryStream stream => encoding.GetString(stream.ToArray()),
+            _ => string.Empty,
+        };
+
+        // OLE string formats are null-terminated; drop the terminator and anything after it.
+        var nullIndex = value.IndexOf('\0');
+        if (nullIndex >= 0)
+        {
+            value = value.Substring(0, nullIndex);
+        }
+
+        value = value.Trim();
+        return value.Length > 0;
+    }
+
+    private static string FirstLine(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+
+        var newlineIndex = value.IndexOfAny(['\r', '\n']);
+        return (newlineIndex >= 0 ? value.Substring(0, newlineIndex) : value).Trim();
+    }
+
+    // Guards against arbitrary dragged text creating junk actions: accept file/UNC paths and real launchable links, but not opaque "scheme:text" shapes that ordinary prose ("Re: ...", "TODO: ...") also parses as.
+    private static bool LooksLikeTarget(string candidate)
+    {
+        if (string.IsNullOrWhiteSpace(candidate))
+            return false;
+
+        if (Uri.TryCreate(candidate, UriKind.Absolute, out var uri) &&
+            (uri.IsFile || uri.IsUnc || uri.Scheme is "http" or "https" or "ftp" or "ftps" or "mailto"))
+        {
+            return true;
+        }
+
+        return File.Exists(candidate) || Directory.Exists(candidate);
+    }
+}

--- a/RadialActions/Settings/ActionsSettingsView.xaml
+++ b/RadialActions/Settings/ActionsSettingsView.xaml
@@ -36,6 +36,9 @@
                 </Grid.RowDefinitions>
 
                 <ListBox Grid.Row="0"
+                         AllowDrop="True"
+                         DragOver="ActionsList_DragOver"
+                         Drop="ActionsList_Drop"
                          ScrollViewer.VerticalScrollBarVisibility="Auto"
                          ScrollViewer.HorizontalScrollBarVisibility="Disabled"
                          ItemsSource="{Binding Actions}"
@@ -73,6 +76,28 @@
                         </DataTemplate>
                     </ListBox.ItemTemplate>
                 </ListBox>
+
+                <TextBlock Grid.Row="0"
+                           Margin="16"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center"
+                           TextAlignment="Center"
+                           TextWrapping="Wrap"
+                           Foreground="Gray"
+                           IsHitTestVisible="False"
+                           Text="Drag files, apps, folders, or links here to add them as actions.">
+                    <TextBlock.Style>
+                        <Style TargetType="TextBlock">
+                            <Setter Property="Visibility" Value="Collapsed" />
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding Actions.Count}"
+                                             Value="0">
+                                    <Setter Property="Visibility" Value="Visible" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </TextBlock.Style>
+                </TextBlock>
 
                 <Grid Grid.Row="1"
                       Margin="0,12,0,0">

--- a/RadialActions/Settings/ActionsSettingsView.xaml.cs
+++ b/RadialActions/Settings/ActionsSettingsView.xaml.cs
@@ -1,9 +1,60 @@
-﻿namespace RadialActions;
+﻿using System.Windows;
+
+namespace RadialActions;
 
 public partial class ActionsSettingsView
 {
+    // DragOver fires many times per second; cache the extracted targets for the current drag so the payload is read once instead of on every tick.
+    private IDataObject _dragData;
+    private IReadOnlyList<string> _dragTargets = [];
+
     public ActionsSettingsView()
     {
         InitializeComponent();
+    }
+
+    private ActionsSettingsViewModel ViewModel => DataContext as ActionsSettingsViewModel;
+
+    private void ActionsList_DragOver(object sender, DragEventArgs e)
+    {
+        e.Effects = GetDropTargets(e.Data).Count > 0 ? DragDropEffects.Copy : DragDropEffects.None;
+        e.Handled = true;
+    }
+
+    private void ActionsList_Drop(object sender, DragEventArgs e)
+    {
+        var targets = GetDropTargets(e.Data);
+        ResetDragCache();
+
+        if (targets.Count == 0)
+            return;
+
+        ViewModel?.AddDroppedTargets(targets);
+        e.Handled = true;
+    }
+
+    private IReadOnlyList<string> GetDropTargets(IDataObject data)
+    {
+        if (ReferenceEquals(data, _dragData))
+            return _dragTargets;
+
+        _dragData = data;
+        try
+        {
+            _dragTargets = ActionDropFactory.ExtractTargets(data);
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Failed to read dropped data");
+            _dragTargets = [];
+        }
+
+        return _dragTargets;
+    }
+
+    private void ResetDragCache()
+    {
+        _dragData = null;
+        _dragTargets = [];
     }
 }

--- a/RadialActions/Settings/ActionsSettingsViewModel.cs
+++ b/RadialActions/Settings/ActionsSettingsViewModel.cs
@@ -56,6 +56,30 @@ public partial class ActionsSettingsViewModel : ObservableObject
         Log.Debug("Added new action");
     }
 
+    /// <summary>
+    /// Creates a prefilled shell action for each dropped target, inserting them after the current selection and selecting the last one.
+    /// </summary>
+    public void AddDroppedTargets(IReadOnlyList<string> targets)
+    {
+        if (targets == null || targets.Count == 0)
+            return;
+
+        var selectedIndex = SelectedAction == null ? -1 : Actions.IndexOf(SelectedAction);
+        var insertionIndex = selectedIndex >= 0 ? selectedIndex + 1 : Actions.Count;
+
+        var added = 0;
+        foreach (var target in targets)
+        {
+            Actions.Insert(insertionIndex, ActionDropFactory.CreateAction(target));
+            insertionIndex++;
+            added++;
+        }
+
+        SelectedActionIndex = insertionIndex - 1;
+        SelectedAction = Actions[SelectedActionIndex];
+        Log.Debug("Added {Count} action(s) from drop", added);
+    }
+
     [RelayCommand]
     private void RemoveAction()
     {


### PR DESCRIPTION
Adds a fast way to create actions: drag **files, folders, apps, shortcuts, or links** (from Explorer, the desktop, or a browser) onto the **Actions** list in Settings, and each becomes a prefilled Shell action. Previously the only path was Add → a blank action → fill every field by hand.

Changes

- **`Actions/ActionDropFactory.cs`** (new) — the testable core:
  - `ExtractTargets(IDataObject)` reads a drop with sensible precedence: dropped **files/folders/shortcuts** (`FileDrop`) first, else a **browser link** (`UniformResourceLocatorW` → ANSI `UniformResourceLocator` → Firefox `text/x-moz-url` → plain text). It decodes null-terminated OLE streams, keeps only the URL line from Firefox's `URL\nTitle`, and de-duplicates.
  - `CreateAction(target)` reuses the existing `ShellActionDefaults.FromTarget` to prefill **name, icon (web/folder/file), and working directory** — the same values the Browse button already produces.
- **`Settings/ActionsSettingsViewModel.cs`** — `AddDroppedTargets` inserts the new actions after the current selection (mirroring the Add button), selects the last, and persists exactly like a manual Add (saved on window close).
- **`Settings/ActionsSettingsView.xaml` / `.xaml.cs`** — the list gains `AllowDrop` with `DragOver`/`Drop` handlers (Copy cursor feedback) and a click-through empty-state hint (*"Drag files, apps, folders, or links here…"*). Handlers stay thin; OLE reads are wrapped in a narrow try/catch, and targets are cached per drag so `DragOver` doesn't re-marshal the payload on every tick.

Design notes

- **Junk-drop guard:** dragged plain text only becomes an action if it's a file/UNC path or a real launchable link (`http`/`https`/`ftp`/`ftps`/`mailto`). Opaque `scheme:text` prose like *"Re: Meeting notes"* or *"TODO: fix bug"* — which `Uri.TryCreate` otherwise treats as a valid absolute URI — is rejected. Real browser links arrive via the dedicated URL formats and are unaffected.
- **No new attack surface:** dropping your own files/apps is the same trust model as the existing Browse button; the action isn't executed on drop.
- **Encoding:** the ANSI `UniformResourceLocator` branch decodes with `Encoding.Latin1` (not UTF-8, and not `Encoding.Default`, which is UTF-8 on .NET 10).
