### PR TITLE
Rework the Key Action editor

### DIFF
--- a/RadialActions.Tests/Actions/PieActionTests.cs
+++ b/RadialActions.Tests/Actions/PieActionTests.cs
@@ -39,6 +39,16 @@ public class PieActionTests
     }
 
     [Fact]
+    public void KeyActions_AllHaveCategoryAndVirtualKey()
+    {
+        foreach (var definition in PieAction.KeyActions)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(definition.Category));
+            Assert.NotEqual(0, definition.VirtualKey);
+        }
+    }
+
+    [Fact]
     public void Execute_NoneAction_ThrowsInvalidOperationException()
     {
         var action = new PieAction();

--- a/RadialActions/Actions/Action.cs
+++ b/RadialActions/Actions/Action.cs
@@ -30,17 +30,19 @@ public enum ActionType
 /// </summary>
 public sealed class KeyActionDefinition
 {
-    public KeyActionDefinition(string id, string name, string icon, byte virtualKey)
+    public KeyActionDefinition(string id, string name, string icon, string category, byte virtualKey)
     {
         Id = id;
         Name = name;
         Icon = icon;
+        Category = category;
         VirtualKey = virtualKey;
     }
 
     public string Id { get; }
     public string Name { get; }
     public string Icon { get; }
+    public string Category { get; }
     public byte VirtualKey { get; }
 }
 
@@ -52,15 +54,22 @@ public partial class PieAction : ObservableObject
     public const string DefaultName = "New Action";
     public const string DefaultIcon = "⚡";
 
+    public const string MediaCategory = "Media";
+    public const string VolumeCategory = "Volume";
+    public const string SystemCategory = "System";
+
     private static readonly IReadOnlyList<KeyActionDefinition> _keyActions =
     [
-        new("PlayPause", "Play/Pause", "⏯️", ActionUtil.VK_MEDIA_PLAY_PAUSE),
-        new("PreviousTrack", "Previous", "⏮️", ActionUtil.VK_MEDIA_PREV_TRACK),
-        new("NextTrack", "Next", "⏭️", ActionUtil.VK_MEDIA_NEXT_TRACK),
-        new("Stop", "Stop", "⏹️", ActionUtil.VK_MEDIA_STOP),
-        new("Mute", "Mute", "🔇", ActionUtil.VK_VOLUME_MUTE),
-        new("VolumeDown", "Volume Down", "🔉", ActionUtil.VK_VOLUME_DOWN),
-        new("VolumeUp", "Volume Up", "🔊", ActionUtil.VK_VOLUME_UP),
+        new("PlayPause", "Play/Pause", "⏯️", MediaCategory, ActionUtil.VK_MEDIA_PLAY_PAUSE),
+        new("PreviousTrack", "Previous Track", "⏮️", MediaCategory, ActionUtil.VK_MEDIA_PREV_TRACK),
+        new("NextTrack", "Next Track", "⏭️", MediaCategory, ActionUtil.VK_MEDIA_NEXT_TRACK),
+        new("Stop", "Stop", "⏹️", MediaCategory, ActionUtil.VK_MEDIA_STOP),
+
+        new("Mute", "Mute", "🔇", VolumeCategory, ActionUtil.VK_VOLUME_MUTE),
+        new("VolumeDown", "Volume Down", "🔉", VolumeCategory, ActionUtil.VK_VOLUME_DOWN),
+        new("VolumeUp", "Volume Up", "🔊", VolumeCategory, ActionUtil.VK_VOLUME_UP),
+
+        new("PrintScreen", "Print Screen", "🖼️", SystemCategory, ActionUtil.VK_SNAPSHOT),
     ];
 
     private static readonly IReadOnlyDictionary<string, KeyActionDefinition> _keyActionsById =

--- a/RadialActions/Actions/ActionUtil.cs
+++ b/RadialActions/Actions/ActionUtil.cs
@@ -21,6 +21,9 @@ public static class ActionUtil
     public const byte VK_VOLUME_DOWN = 0xAE;
     public const byte VK_VOLUME_UP = 0xAF;
 
+    // System Keys
+    public const byte VK_SNAPSHOT = 0x2C; // Print Screen
+
     // Modifier Keys
     public const byte VK_CONTROL = 0x11;
     public const byte VK_MENU = 0x12; // Alt
@@ -140,7 +143,8 @@ public static class ActionUtil
             or VK_MEDIA_STOP
             or VK_VOLUME_MUTE
             or VK_VOLUME_DOWN
-            or VK_VOLUME_UP;
+            or VK_VOLUME_UP
+            or VK_SNAPSHOT;
     }
 
     private static bool TrySendMediaAppCommand(byte vk)

--- a/RadialActions/Settings/ActionEditorView.xaml
+++ b/RadialActions/Settings/ActionEditorView.xaml
@@ -61,7 +61,22 @@
             <ComboBox SelectedValue="{Binding SelectedKeyActionId, Mode=TwoWay}"
                       SelectedValuePath="Id"
                       IsTextSearchEnabled="True"
-                      ItemsSource="{Binding KeyActionOptions}">
+                      TextSearch.TextPath="Name"
+                      MaxDropDownHeight="420"
+                      ItemsSource="{Binding KeyActionOptionsView}">
+                <ComboBox.GroupStyle>
+                    <GroupStyle>
+                        <GroupStyle.HeaderTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Name}"
+                                           FontSize="11"
+                                           FontWeight="SemiBold"
+                                           Opacity="0.6"
+                                           Margin="6,6,0,2" />
+                            </DataTemplate>
+                        </GroupStyle.HeaderTemplate>
+                    </GroupStyle>
+                </ComboBox.GroupStyle>
                 <ComboBox.ItemTemplate>
                     <DataTemplate>
                         <StackPanel Orientation="Horizontal">
@@ -75,15 +90,16 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-            <TextBlock Text="Choose a built-in command or Custom Shortcut."
+            <TextBlock Text="Pick a media, volume, or system command, or record your own shortcut with Custom Shortcut."
                        Style="{StaticResource DescriptionTextBlock}" />
 
             <TextBlock Text="Shortcut:"
                        Style="{StaticResource ActionEditorLabelTextBlock}"
                        Visibility="{Binding SelectedKeyActionId, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionEditorViewModel.CustomKeyActionId}}" />
             <TextBox Text="{Binding SelectedAction.Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                     Tag="HotkeyInput"
                      Visibility="{Binding SelectedKeyActionId, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionEditorViewModel.CustomKeyActionId}}" />
-            <TextBlock Text="Enter a shortcut, such as Ctrl+Shift+M."
+            <TextBlock Text="Click the box, then press the key combination to record it, such as Ctrl+Shift+M. Press Backspace to clear."
                        Style="{StaticResource DescriptionTextBlock}"
                        Visibility="{Binding SelectedKeyActionId, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionEditorViewModel.CustomKeyActionId}}" />
         </StackPanel>

--- a/RadialActions/Settings/ActionEditorViewModel.cs
+++ b/RadialActions/Settings/ActionEditorViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using System.Windows.Data;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Microsoft.Win32;
@@ -10,7 +11,7 @@ public partial class ActionEditorViewModel : ObservableObject
     public const string CustomKeyActionId = "__custom__";
 
     private static readonly KeyActionDefinition CustomKeyActionOption =
-        new(CustomKeyActionId, "Custom Shortcut...", "⌨️", 0);
+        new(CustomKeyActionId, "Custom Shortcut...", "⌨️", "Custom", 0);
 
     private readonly ActionDefaultsService _actionDefaultsService;
 
@@ -24,6 +25,10 @@ public partial class ActionEditorViewModel : ObservableObject
     {
         _actionDefaultsService = actionDefaultsService;
         _actionDefaultsService.TrackExistingDefaults(actions);
+
+        var view = new ListCollectionView((System.Collections.IList)KeyActionOptions);
+        view.GroupDescriptions.Add(new PropertyGroupDescription(nameof(KeyActionDefinition.Category)));
+        KeyActionOptionsView = view;
     }
 
     public IReadOnlyList<ActionTypeOption> ActionTypes { get; } =
@@ -34,6 +39,12 @@ public partial class ActionEditorViewModel : ObservableObject
 
     public IReadOnlyList<KeyActionDefinition> KeyActionOptions { get; } =
         [.. PieAction.KeyActions, CustomKeyActionOption];
+
+    /// <summary>
+    /// Key action options grouped by category for display in the editor.
+    /// </summary>
+    public ICollectionView KeyActionOptionsView { get; }
+
     public bool HasSelectedAction => SelectedAction != null;
 
     public ActionType SelectedActionType

--- a/RadialActions/Settings/GeneralSettingsView.xaml
+++ b/RadialActions/Settings/GeneralSettingsView.xaml
@@ -38,7 +38,7 @@
                     <TextBlock Text="Hotkey:"
                                Style="{StaticResource LabelTextBlock}" />
                     <TextBox Text="{Binding Settings.ActivationHotkey, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                             Tag="ActivationHotkeyInput" />
+                             Tag="HotkeyInput" />
                     <TextBlock Text="Press a key combination, such as Ctrl+Alt+Space."
                                Style="{StaticResource DescriptionTextBlock}" />
                 </StackPanel>

--- a/RadialActions/SettingsWindow.xaml.cs
+++ b/RadialActions/SettingsWindow.xaml.cs
@@ -23,7 +23,7 @@ public partial class SettingsWindow : Window
         DataContext = _viewModel;
         Closed += OnClosed;
         AddHandler(Hyperlink.RequestNavigateEvent, new RequestNavigateEventHandler(Hyperlink_RequestNavigate));
-        AddHandler(Keyboard.PreviewKeyDownEvent, new KeyEventHandler(ActivationHotkey_PreviewKeyDown), handledEventsToo: true);
+        AddHandler(Keyboard.PreviewKeyDownEvent, new KeyEventHandler(HotkeyInput_PreviewKeyDown), handledEventsToo: true);
     }
 
     public void SelectAction(PieAction action)
@@ -75,9 +75,9 @@ public partial class SettingsWindow : Window
         }
     }
 
-    private void ActivationHotkey_PreviewKeyDown(object sender, KeyEventArgs e)
+    private void HotkeyInput_PreviewKeyDown(object sender, KeyEventArgs e)
     {
-        if (e.OriginalSource is not TextBox { Tag: "ActivationHotkeyInput" } textBox)
+        if (e.OriginalSource is not TextBox { Tag: "HotkeyInput" } textBox)
             return;
 
         var key = e.Key == Key.System ? e.SystemKey : e.Key;


### PR DESCRIPTION
Reworks the Key Action editor to be easier to use and adds a new option.

## Changes

- The Key Action dropdown is now grouped by category (Media, Volume, System, Custom) with headers, instead of one flat list. Type-to-search works within it.
- New built-in action: **Print Screen** (copies the screen to the clipboard).
- The custom shortcut field is now a press-to-record box: click it and press the actual key combination (e.g. Ctrl+Shift+M) instead of typing the text by hand. Backspace clears it. It reuses the same recorder behavior as the activation hotkey field in General settings.
- Track actions renamed to "Previous Track" / "Next Track" for clarity.

All existing action IDs are unchanged, so saved settings keep working.

## Tests

- New test asserting every catalog entry has a category and a virtual key.
- Full suite passes (117 tests).