### PR TITLE
Trigger slices with number keys 1-9

### DIFF
--- a/RadialActions.Tests/Pie/PieSelectionControllerTests.cs
+++ b/RadialActions.Tests/Pie/PieSelectionControllerTests.cs
@@ -1,4 +1,4 @@
-using System.Windows.Input;
+﻿using System.Windows.Input;
 
 namespace RadialActions.Tests;
 
@@ -62,6 +62,46 @@ public class PieSelectionControllerTests
         controller.HandleArrowKey(key, items);
 
         Assert.Equal(0, controller.SelectedIndex);
+    }
+
+    [Theory]
+    [InlineData(1, 0)]
+    [InlineData(2, 2)]
+    [InlineData(3, 5)]
+    public void TrySelectDigit_SelectsItemAtClockwisePosition(int digit, int expectedIndex)
+    {
+        var controller = new PieSelectionController();
+        PieSelectionController.Item[] items =
+        [
+            new(0, -60),
+            new(2, 60),
+            new(5, 180),
+        ];
+
+        var selected = controller.TrySelectDigit(digit, items);
+
+        Assert.True(selected);
+        Assert.Equal(expectedIndex, controller.SelectedIndex);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(4)]
+    [InlineData(9)]
+    public void TrySelectDigit_ReturnsFalseWhenDigitHasNoSlice(int digit)
+    {
+        var controller = new PieSelectionController();
+        PieSelectionController.Item[] items =
+        [
+            new(0, -60),
+            new(1, 60),
+            new(2, 180),
+        ];
+
+        var selected = controller.TrySelectDigit(digit, items);
+
+        Assert.False(selected);
+        Assert.Equal(PieSelectionController.NoSelection, controller.SelectedIndex);
     }
 
     [Fact]

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -26,6 +26,17 @@ public partial class PieControl : UserControl
     private const double MouseMoveThreshold = 0.25;
 
     /// <summary>
+    /// The number keys 1-9 trigger slices, so hints are only shown for the first nine.
+    /// </summary>
+    private const int MaxDigitHints = 9;
+
+    /// <summary>
+    /// How far from the center the digit hints sit, as a fraction of the outer radius.
+    /// Keeps them near the rim, clear of the icon and label at the slice midpoint.
+    /// </summary>
+    private const double DigitHintRadiusRatio = 0.9;
+
+    /// <summary>
     /// How far the pointer must travel with the button held before a press becomes a drag.
     /// Deliberately much larger than the system drag threshold so held-but-jittering clicks
     /// during normal use never start reordering.
@@ -597,6 +608,21 @@ public partial class PieControl : UserControl
             };
             Panel.SetZIndex(slice, SliceZIndex);
             PieCanvas.Children.Add(slice);
+
+            if (i < MaxDigitHints)
+            {
+                var digitHint = PieVisualBuilder.CreateSliceDigitHint(
+                    i + 1,
+                    theme.LabelTextStyle,
+                    theme.LabelTextColor,
+                    theme.IsHighContrast);
+                digitHint.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+                var hintPosition = PieLayoutCalculator.GetTextPosition(center, outerRadius * DigitHintRadiusRatio, startAngle, endAngle, SnapPoint);
+                Canvas.SetLeft(digitHint, SnapToDevicePixel(hintPosition.X - (digitHint.DesiredSize.Width / 2), isXAxis: true));
+                Canvas.SetTop(digitHint, SnapToDevicePixel(hintPosition.Y - (digitHint.DesiredSize.Height / 2), isXAxis: false));
+                Panel.SetZIndex(digitHint, SliceContentZIndex);
+                PieCanvas.Children.Add(digitHint);
+            }
 
             var textRadius = innerRadius > 0 ? (outerRadius + innerRadius) / 2 : outerRadius * 0.6;
             var textPosition = PieLayoutCalculator.GetTextPosition(center, textRadius, startAngle, endAngle, SnapPoint);

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -137,9 +137,29 @@ public partial class PieControl : UserControl
                 return OpenSelectedSliceContextMenu();
             case Key.F10 when modifiers.HasFlag(ModifierKeys.Shift):
                 return OpenSelectedSliceContextMenu();
+            case >= Key.D1 and <= Key.D9:
+                return HandleDigitKey(key - Key.D1 + 1);
+            case >= Key.NumPad1 and <= Key.NumPad9:
+                return HandleDigitKey(key - Key.NumPad1 + 1);
             default:
                 return false;
         }
+    }
+
+    private bool HandleDigitKey(int digit)
+    {
+        if (!_selectionController.TrySelectDigit(digit, GetSelectionItems()))
+        {
+            return false;
+        }
+
+        Log.Debug("Digit key {Digit} pressed; activating selected slice", digit);
+        _interactionMode = InteractionMode.Keyboard;
+        _keyboardModeMousePosition = Mouse.GetPosition(PieCanvas);
+        _hasKeyboardModeMousePosition = true;
+        RefreshVisualState(animate: false);
+        ActivateSelectedSlice();
+        return true;
     }
 
     private void OnPieCanvasMouseMove(object sender, MouseEventArgs e)

--- a/RadialActions/Pie/PieSelectionController.cs
+++ b/RadialActions/Pie/PieSelectionController.cs
@@ -1,4 +1,4 @@
-using System.Windows.Input;
+﻿using System.Windows.Input;
 
 namespace RadialActions;
 
@@ -26,6 +26,19 @@ internal sealed class PieSelectionController
         {
             SelectedIndex = NoSelection;
         }
+    }
+
+    public bool TrySelectDigit(int digit, IReadOnlyList<Item> items)
+    {
+        // Digits count clockwise from the top; items are provided in that visual order.
+        var position = digit - 1;
+        if (position < 0 || position >= items.Count)
+        {
+            return false;
+        }
+
+        SelectedIndex = items[position].Index;
+        return true;
     }
 
     public void HandleArrowKey(Key key, IReadOnlyList<Item> items)

--- a/RadialActions/Pie/PieVisualBuilder.cs
+++ b/RadialActions/Pie/PieVisualBuilder.cs
@@ -114,6 +114,25 @@ public static class PieVisualBuilder
         return new CenterElements(centerCloseTarget, centerFillBrush, centerStrokeBrush, centerCloseIcon);
     }
 
+    public static TextBlock CreateSliceDigitHint(
+        int digit,
+        Style labelTextStyle,
+        Color labelTextColor,
+        bool isHighContrast)
+    {
+        return new TextBlock
+        {
+            Style = labelTextStyle,
+            Text = digit.ToString(),
+            Foreground = new SolidColorBrush(labelTextColor),
+            FontSize = 10,
+            FontWeight = FontWeights.SemiBold,
+            Opacity = isHighContrast ? 1 : 0.55,
+            IsHitTestVisible = false,
+            SnapsToDevicePixels = true,
+        };
+    }
+
     public static StackPanel CreateSliceContentPanel(
         PieAction sliceAction,
         Style iconTextStyle,

--- a/RadialActions/Pie/PieVisualBuilder.cs
+++ b/RadialActions/Pie/PieVisualBuilder.cs
@@ -125,9 +125,9 @@ public static class PieVisualBuilder
             Style = labelTextStyle,
             Text = digit.ToString(),
             Foreground = new SolidColorBrush(labelTextColor),
-            FontSize = 10,
-            FontWeight = FontWeights.SemiBold,
-            Opacity = isHighContrast ? 1 : 0.55,
+            FontSize = 9,
+            FontWeight = FontWeights.Normal,
+            Opacity = isHighContrast ? 1 : 0.3,
             IsHitTestVisible = false,
             SnapsToDevicePixels = true,
         };


### PR DESCRIPTION
Closes #56: while the menu is open, pressing 1-9 (top row or numpad) selects and immediately triggers the corresponding slice, counting clockwise from the top. Each of the first nine slices shows a small muted digit hint near its rim so the mapping is discoverable. Combined with the global hotkey, an action can now be run entirely from the keyboard.

<img width="536" height="509" alt="image" src="https://github.com/user-attachments/assets/b9e69f2c-b189-4bca-95d0-02a756c03f70" />

## Design

- `PieSelectionController.TrySelectDigit(digit, items)` maps digit N to the Nth item in visual order and updates `SelectedIndex`. It returns `false` (key not handled) when the digit has no slice.
- `PieControl.HandleMenuKey` routes `D1`-`D9` and `NumPad1`-`NumPad9` to a new `HandleDigitKey`, which selects the slice, enters keyboard interaction mode (reusing the arrow-key plumbing), refreshes the visual state so the slice shows its selected look for the brief moment before the menu closes, and raises `SliceClicked`.
- Disabled actions are never rendered as slices, so the numbering skips them for free, matching the visual layout.
- Digit hints are built by `PieVisualBuilder.CreateSliceDigitHint` and placed at 0.9x the outer radius along each slice midline, clear of the icon/label content at the slice midpoint. They use the theme label color at 55% opacity (full opacity in high contrast) and are not hit-testable.

## Validation

- `dotnet build RadialActions.sln` - 0 warnings, 0 errors.
- `dotnet test RadialActions.sln` - 122 passed, 0 failed (includes new `TrySelectDigit` tests for position mapping and out-of-range digits).
- Hint placement/legibility should get a quick visual check on Windows before merge.

## Risks

Low. Digit keys were previously unhandled while the menu was open, and unmatched digits (e.g. pressing 7 with 4 slices) still fall through unhandled. The hints stay fixed during a drag-reorder; numbering is positional and the menu rebuilds when the drag commits.