### PR TITLE
New action type: system actions (lock, sleep, screenshot, etc.)

### DIFF
--- a/RadialActions.Tests/Actions/ActionDefaultsServiceTests.cs
+++ b/RadialActions.Tests/Actions/ActionDefaultsServiceTests.cs
@@ -1,4 +1,4 @@
-namespace RadialActions.Tests;
+﻿namespace RadialActions.Tests;
 
 public sealed class ActionDefaultsServiceTests : IDisposable
 {
@@ -28,6 +28,43 @@ public sealed class ActionDefaultsServiceTests : IDisposable
         autoAction.Icon = mute.Icon;
         service.ApplyKeyDefaults(autoAction, volumeUp);
         Assert.Equal(volumeUp.Icon, autoAction.Icon);
+    }
+
+    [Fact]
+    public void ApplySystemDefaults_UpdatesNameAndIconOnlyForBlankDefaultOrPreviousAutoValue()
+    {
+        var service = new ActionDefaultsService();
+        var defaultAction = new PieAction { Type = ActionType.System, Parameter = "LockWorkstation" };
+        var manualAction = new PieAction("My Lock") { Type = ActionType.System, Parameter = "LockWorkstation", Icon = "\U0001F3B5" };
+        var autoAction = new PieAction { Type = ActionType.System, Parameter = "LockWorkstation" };
+        var lockAction = FindSystemAction("LockWorkstation");
+        var sleepAction = FindSystemAction("Sleep");
+
+        service.ApplySystemDefaults(defaultAction, lockAction);
+        Assert.Equal(lockAction.Name, defaultAction.Name);
+        Assert.Equal(lockAction.Icon, defaultAction.Icon);
+
+        service.ApplySystemDefaults(manualAction, lockAction);
+        Assert.Equal("My Lock", manualAction.Name);
+        Assert.Equal("\U0001F3B5", manualAction.Icon);
+
+        service.ApplySystemDefaults(autoAction, lockAction);
+        service.ApplySystemDefaults(autoAction, sleepAction);
+        Assert.Equal(sleepAction.Name, autoAction.Name);
+        Assert.Equal(sleepAction.Icon, autoAction.Icon);
+    }
+
+    [Fact]
+    public void EnsureSystemDefaults_UnknownParameter_ResetsToFirstKnownAction()
+    {
+        var service = new ActionDefaultsService();
+        var action = new PieAction { Type = ActionType.System, Parameter = "not-a-real-id" };
+
+        service.EnsureSystemDefaults(action);
+
+        Assert.Equal(PieAction.SystemActions[0].Id, action.Parameter);
+        Assert.Equal(PieAction.SystemActions[0].Name, action.Name);
+        Assert.Equal(PieAction.SystemActions[0].Icon, action.Icon);
     }
 
     [Fact]
@@ -78,6 +115,12 @@ public sealed class ActionDefaultsServiceTests : IDisposable
     private static KeyActionDefinition FindKeyAction(string id)
     {
         Assert.True(PieAction.TryGetKeyAction(id, out var definition));
+        return definition;
+    }
+
+    private static SystemActionDefinition FindSystemAction(string id)
+    {
+        Assert.True(PieAction.TryGetSystemAction(id, out var definition));
         return definition;
     }
 }

--- a/RadialActions.Tests/Actions/ActionsSettingsViewModelTests.cs
+++ b/RadialActions.Tests/Actions/ActionsSettingsViewModelTests.cs
@@ -121,7 +121,7 @@ public sealed class ActionsSettingsViewModelTests
     {
         var viewModel = new ActionEditorViewModel(new ActionDefaultsService(), []);
 
-        Assert.Equal([ActionType.Key, ActionType.Shell], viewModel.ActionTypes.Select(option => option.Type));
+        Assert.Equal([ActionType.Key, ActionType.Shell, ActionType.System], viewModel.ActionTypes.Select(option => option.Type));
     }
 
     [Fact]

--- a/RadialActions.Tests/Actions/PieActionTests.cs
+++ b/RadialActions.Tests/Actions/PieActionTests.cs
@@ -39,6 +39,44 @@ public class PieActionTests
     }
 
     [Fact]
+    public void CreateSystemAction_UnknownId_UsesFirstKnownAction()
+    {
+        var action = PieAction.CreateSystemAction("not-a-real-id");
+
+        Assert.Equal(ActionType.System, action.Type);
+        Assert.True(action.IsEnabled);
+        Assert.Equal(PieAction.SystemActions[0].Id, action.Parameter);
+        Assert.Equal(PieAction.SystemActions[0].Name, action.Name);
+        Assert.Equal(PieAction.SystemActions[0].Icon, action.Icon);
+    }
+
+    [Fact]
+    public void TryGetSystemAction_KnownId_ReturnsDefinition()
+    {
+        var ok = PieAction.TryGetSystemAction("LockWorkstation", out var definition);
+
+        Assert.True(ok);
+        Assert.NotNull(definition);
+        Assert.Equal("LockWorkstation", definition.Id);
+    }
+
+    [Fact]
+    public void SystemActions_AreConfiguredCorrectly()
+    {
+        Assert.NotEmpty(PieAction.SystemActions);
+
+        var ids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var definition in PieAction.SystemActions)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(definition.Id));
+            Assert.False(string.IsNullOrWhiteSpace(definition.Name));
+            Assert.False(string.IsNullOrWhiteSpace(definition.Icon));
+            Assert.NotNull(definition.Execute);
+            Assert.True(ids.Add(definition.Id), $"Duplicate system action id: {definition.Id}");
+        }
+    }
+
+    [Fact]
     public void Execute_NoneAction_ThrowsInvalidOperationException()
     {
         var action = new PieAction();
@@ -56,6 +94,30 @@ public class PieActionTests
         var ex = Assert.Throws<InvalidOperationException>(() => action.Execute());
 
         Assert.Equal("Launch target not configured", ex.Message);
+    }
+
+    [Fact]
+    public void Execute_SystemActionWithoutParameter_ThrowsInvalidOperationException()
+    {
+        var action = new PieAction("System") { Type = ActionType.System };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => action.Execute());
+
+        Assert.Equal("System action not configured", ex.Message);
+    }
+
+    [Fact]
+    public void Execute_SystemActionWithUnknownId_ThrowsInvalidOperationException()
+    {
+        var action = new PieAction("System")
+        {
+            Type = ActionType.System,
+            Parameter = "not-a-real-id"
+        };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => action.Execute());
+
+        Assert.Equal("System action is unknown", ex.Message);
     }
 
     [Fact]

--- a/RadialActions.Tests/Settings/SettingsSerializationTests.cs
+++ b/RadialActions.Tests/Settings/SettingsSerializationTests.cs
@@ -69,7 +69,8 @@ public class SettingsSerializationTests
         settings.Actions = new System.Collections.ObjectModel.ObservableCollection<PieAction>
         {
             PieAction.CreateKeyAction("Mute"),
-            PieAction.CreateShellAction("Explorer", "explorer.exe")
+            PieAction.CreateShellAction("Explorer", "explorer.exe"),
+            PieAction.CreateSystemAction("LockWorkstation")
         };
         settings.Actions[1].IsEnabled = false;
 
@@ -79,13 +80,16 @@ public class SettingsSerializationTests
         Assert.Equal("Ctrl+Shift+R", loaded.ActivationHotkey);
         Assert.Equal(512, loaded.Size);
         Assert.True(loaded.OpenMenuInScreenCenter);
-        Assert.Equal(2, loaded.Actions.Count);
+        Assert.Equal(3, loaded.Actions.Count);
         Assert.Equal(ActionType.Key, loaded.Actions[0].Type);
         Assert.Equal("Mute", loaded.Actions[0].Parameter);
         Assert.True(loaded.Actions[0].IsEnabled);
         Assert.Equal(ActionType.Shell, loaded.Actions[1].Type);
         Assert.Equal("explorer.exe", loaded.Actions[1].Parameter);
         Assert.False(loaded.Actions[1].IsEnabled);
+        Assert.Equal(ActionType.System, loaded.Actions[2].Type);
+        Assert.Equal("LockWorkstation", loaded.Actions[2].Parameter);
+        Assert.True(loaded.Actions[2].IsEnabled);
     }
 
     [Fact]

--- a/RadialActions/Actions/Action.cs
+++ b/RadialActions/Actions/Action.cs
@@ -23,6 +23,11 @@ public enum ActionType
     /// Launch an app, open a file, or open a URL using shell execution.
     /// </summary>
     Shell = 2,
+
+    /// <summary>
+    /// Run a built-in system command like locking the workstation.
+    /// </summary>
+    System = 3,
 }
 
 /// <summary>
@@ -42,6 +47,25 @@ public sealed class KeyActionDefinition
     public string Name { get; }
     public string Icon { get; }
     public byte VirtualKey { get; }
+}
+
+/// <summary>
+/// Defines a selectable system action.
+/// </summary>
+public sealed class SystemActionDefinition
+{
+    public SystemActionDefinition(string id, string name, string icon, Action execute)
+    {
+        Id = id;
+        Name = name;
+        Icon = icon;
+        Execute = execute;
+    }
+
+    public string Id { get; }
+    public string Name { get; }
+    public string Icon { get; }
+    public Action Execute { get; }
 }
 
 /// <summary>
@@ -68,10 +92,31 @@ public partial class PieAction : ObservableObject
 
     public static IReadOnlyList<KeyActionDefinition> KeyActions => _keyActions;
 
+    private static readonly IReadOnlyList<SystemActionDefinition> _systemActions =
+    [
+        new("LockWorkstation", "Lock", "🔒", SystemActionUtil.LockWorkstation),
+        new("Sleep", "Sleep", "🌙", SystemActionUtil.Sleep),
+        new("ShowDesktop", "Show Desktop", "🖥️", SystemActionUtil.ShowDesktop),
+        new("Screenshot", "Screenshot", "📸", SystemActionUtil.Screenshot),
+        new("EmptyRecycleBin", "Empty Recycle Bin", "🗑️", SystemActionUtil.EmptyRecycleBin),
+        new("ToggleDarkMode", "Toggle Dark Mode", "🌓", SystemActionUtil.ToggleDarkMode),
+    ];
+
+    private static readonly IReadOnlyDictionary<string, SystemActionDefinition> _systemActionsById =
+        _systemActions.ToDictionary(action => action.Id, StringComparer.OrdinalIgnoreCase);
+
+    public static IReadOnlyList<SystemActionDefinition> SystemActions => _systemActions;
+
     public static bool TryGetKeyAction(string id, out KeyActionDefinition definition)
     {
         definition = null;
         return !string.IsNullOrWhiteSpace(id) && _keyActionsById.TryGetValue(id, out definition);
+    }
+
+    public static bool TryGetSystemAction(string id, out SystemActionDefinition definition)
+    {
+        definition = null;
+        return !string.IsNullOrWhiteSpace(id) && _systemActionsById.TryGetValue(id, out definition);
     }
 
     /// <summary>
@@ -148,6 +193,23 @@ public partial class PieAction : ObservableObject
     }
 
     /// <summary>
+    /// Creates a system action.
+    /// </summary>
+    public static PieAction CreateSystemAction(string systemActionId)
+    {
+        if (!TryGetSystemAction(systemActionId, out var definition))
+        {
+            definition = _systemActions[0];
+        }
+
+        return new PieAction(definition.Name, definition.Icon)
+        {
+            Type = ActionType.System,
+            Parameter = definition.Id,
+        };
+    }
+
+    /// <summary>
     /// Creates a shell action.
     /// </summary>
     public static PieAction CreateShellAction(string name, string target, string icon = "📁", string arguments = "", string workingDirectory = "")
@@ -176,6 +238,9 @@ public partial class PieAction : ObservableObject
             case ActionType.Shell:
                 ExecuteShell();
                 return;
+            case ActionType.System:
+                ExecuteSystem();
+                return;
             default:
                 throw new NotSupportedException("Action type is not supported");
         }
@@ -196,6 +261,17 @@ public partial class PieAction : ObservableObject
             throw new InvalidOperationException("Shortcut is invalid");
 
         ActionUtil.SimulateKeyboardShortcut(Parameter);
+    }
+
+    private void ExecuteSystem()
+    {
+        if (string.IsNullOrWhiteSpace(Parameter))
+            throw new InvalidOperationException("System action not configured");
+
+        if (!TryGetSystemAction(Parameter, out var definition))
+            throw new InvalidOperationException("System action is unknown");
+
+        definition.Execute();
     }
 
     private void ExecuteShell()

--- a/RadialActions/Actions/ActionDefaultsService.cs
+++ b/RadialActions/Actions/ActionDefaultsService.cs
@@ -1,10 +1,11 @@
-namespace RadialActions;
+﻿namespace RadialActions;
 
 public sealed class ActionDefaultsService
 {
     public const string LegacyDefaultIcon = "\u2B50";
 
     private readonly Dictionary<PieAction, KeyActionDefinition> _autoKeyDefaults = [];
+    private readonly Dictionary<PieAction, SystemActionDefinition> _autoSystemDefaults = [];
     private readonly Dictionary<PieAction, ShellActionDefaults> _autoShellDefaults = [];
 
     public ShellActionDefaults? GetShellDefaults(string target) => ShellActionDefaults.FromTarget(target);
@@ -12,12 +13,14 @@ public sealed class ActionDefaultsService
     public void Forget(PieAction action)
     {
         _autoKeyDefaults.Remove(action);
+        _autoSystemDefaults.Remove(action);
         _autoShellDefaults.Remove(action);
     }
 
     public void TrackExistingDefaults(IEnumerable<PieAction> actions)
     {
         _autoKeyDefaults.Clear();
+        _autoSystemDefaults.Clear();
         _autoShellDefaults.Clear();
 
         foreach (var action in actions)
@@ -27,6 +30,13 @@ public sealed class ActionDefaultsService
                 if (PieAction.TryGetKeyAction(action.Parameter, out var definition))
                 {
                     _autoKeyDefaults[action] = definition;
+                }
+            }
+            else if (action.Type == ActionType.System)
+            {
+                if (PieAction.TryGetSystemAction(action.Parameter, out var definition))
+                {
+                    _autoSystemDefaults[action] = definition;
                 }
             }
             else if (action.Type == ActionType.Shell)
@@ -67,6 +77,38 @@ public sealed class ActionDefaultsService
         }
 
         _autoKeyDefaults[action] = definition;
+    }
+
+    public void EnsureSystemDefaults(PieAction action)
+    {
+        if (action.Type != ActionType.System)
+            return;
+
+        if (!PieAction.TryGetSystemAction(action.Parameter, out var definition))
+        {
+            definition = PieAction.SystemActions[0];
+            action.Parameter = definition.Id;
+        }
+
+        ApplySystemDefaults(action, definition);
+    }
+
+    public void ApplySystemDefaults(PieAction action, SystemActionDefinition definition)
+    {
+        _autoSystemDefaults.TryGetValue(action, out var previous);
+
+        if (ShouldApplyDefault(action.Name, PieAction.DefaultName, previous?.Name ?? string.Empty))
+        {
+            action.Name = definition.Name;
+        }
+
+        if (ShouldApplyDefault(action.Icon, PieAction.DefaultIcon, previous?.Icon ?? string.Empty) ||
+            action.Icon == LegacyDefaultIcon)
+        {
+            action.Icon = definition.Icon;
+        }
+
+        _autoSystemDefaults[action] = definition;
     }
 
     public void ApplyShellDefaults(PieAction action, string target)

--- a/RadialActions/Actions/SystemActionUtil.cs
+++ b/RadialActions/Actions/SystemActionUtil.cs
@@ -1,0 +1,84 @@
+﻿using System.Runtime.InteropServices;
+using Microsoft.Win32;
+
+namespace RadialActions;
+
+/// <summary>
+/// Executes built-in system actions like locking the workstation or toggling dark mode.
+/// </summary>
+public static class SystemActionUtil
+{
+    private const uint SHERB_NOCONFIRMATION = 0x00000001;
+
+    private const int HWND_BROADCAST = 0xFFFF;
+    private const int WM_SETTINGCHANGE = 0x001A;
+    private const uint SMTO_ABORTIFHUNG = 0x0002;
+
+    private const string PersonalizeKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize";
+
+    [DllImport("user32.dll", SetLastError = true)]
+    private static extern bool LockWorkStation();
+
+    [DllImport("powrprof.dll", SetLastError = true)]
+    private static extern bool SetSuspendState(bool bHibernate, bool bForce, bool bWakeupEventsDisabled);
+
+    [DllImport("shell32.dll")]
+    private static extern int SHEmptyRecycleBin(IntPtr hwnd, string pszRootPath, uint dwFlags);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern IntPtr SendMessageTimeout(IntPtr hWnd, int msg, IntPtr wParam, string lParam, uint fuFlags, uint uTimeout, out IntPtr lpdwResult);
+
+    /// <summary>
+    /// Locks the workstation, same as Win+L.
+    /// </summary>
+    public static void LockWorkstation()
+    {
+        if (!LockWorkStation())
+            throw new InvalidOperationException("Could not lock the workstation");
+    }
+
+    /// <summary>
+    /// Puts the computer to sleep.
+    /// </summary>
+    public static void Sleep()
+    {
+        if (!SetSuspendState(false, false, false))
+            throw new InvalidOperationException("Could not put the computer to sleep");
+    }
+
+    /// <summary>
+    /// Minimizes all windows to show the desktop, same as Win+D.
+    /// </summary>
+    public static void ShowDesktop() => ActionUtil.SimulateKeyboardShortcut("Win+D");
+
+    /// <summary>
+    /// Opens the snipping overlay to capture a screenshot, same as Win+Shift+S.
+    /// </summary>
+    public static void Screenshot() => ActionUtil.SimulateKeyboardShortcut("Win+Shift+S");
+
+    /// <summary>
+    /// Empties the recycle bin without a confirmation prompt.
+    /// </summary>
+    public static void EmptyRecycleBin()
+    {
+        // The result is ignored because it reports an error for benign cases like the bin already being empty.
+        _ = SHEmptyRecycleBin(IntPtr.Zero, null, SHERB_NOCONFIRMATION);
+    }
+
+    /// <summary>
+    /// Toggles Windows between light and dark mode for apps and the system.
+    /// </summary>
+    public static void ToggleDarkMode()
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(PersonalizeKeyPath, writable: true) ??
+            throw new InvalidOperationException("Could not open the personalization settings");
+
+        var useLightTheme = key.GetValue("AppsUseLightTheme") as int? ?? 1;
+        var newValue = useLightTheme == 0 ? 1 : 0;
+        key.SetValue("AppsUseLightTheme", newValue, RegistryValueKind.DWord);
+        key.SetValue("SystemUsesLightTheme", newValue, RegistryValueKind.DWord);
+
+        // Tells running apps to re-read the theme so the change applies immediately.
+        SendMessageTimeout((IntPtr)HWND_BROADCAST, WM_SETTINGCHANGE, IntPtr.Zero, "ImmersiveColorSet", SMTO_ABORTIFHUNG, 1000, out _);
+    }
+}

--- a/RadialActions/Settings/ActionEditorView.xaml
+++ b/RadialActions/Settings/ActionEditorView.xaml
@@ -51,7 +51,7 @@
                 </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>
-        <TextBlock Text="Use Key for shortcuts and media controls; Shell for apps, files, folders, URLs, or commands."
+        <TextBlock Text="Use Key for shortcuts and media controls; Shell for apps, files, folders, URLs, or commands; System for built-in Windows commands."
                    Style="{StaticResource DescriptionTextBlock}" />
 
         <StackPanel Margin="0,0,0,4"
@@ -86,6 +86,31 @@
             <TextBlock Text="Enter a shortcut, such as Ctrl+Shift+M."
                        Style="{StaticResource DescriptionTextBlock}"
                        Visibility="{Binding SelectedKeyActionId, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionEditorViewModel.CustomKeyActionId}}" />
+        </StackPanel>
+
+        <StackPanel Margin="0,0,0,4"
+              Visibility="{Binding SelectedActionType, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionType.System}}">
+            <TextBlock Text="System Action:"
+                       Style="{StaticResource ActionEditorLabelTextBlock}" />
+            <ComboBox SelectedValue="{Binding SelectedSystemActionId, Mode=TwoWay}"
+                      SelectedValuePath="Id"
+                      IsTextSearchEnabled="True"
+                      ItemsSource="{Binding SystemActionOptions}">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock Text="{Binding Icon}"
+                                       Width="20"
+                                       FontSize="14" />
+                            <TextBlock Text="{Binding Name}"
+                                       Margin="4,0,0,0"
+                                       VerticalAlignment="Center" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <TextBlock Text="Choose a built-in command. It runs immediately when the slice is clicked."
+                       Style="{StaticResource DescriptionTextBlock}" />
         </StackPanel>
 
         <StackPanel

--- a/RadialActions/Settings/ActionEditorViewModel.cs
+++ b/RadialActions/Settings/ActionEditorViewModel.cs
@@ -18,6 +18,7 @@ public partial class ActionEditorViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(HasSelectedAction))]
     [NotifyPropertyChangedFor(nameof(SelectedActionType))]
     [NotifyPropertyChangedFor(nameof(SelectedKeyActionId))]
+    [NotifyPropertyChangedFor(nameof(SelectedSystemActionId))]
     private PieAction _selectedAction;
 
     public ActionEditorViewModel(ActionDefaultsService actionDefaultsService, IEnumerable<PieAction> actions)
@@ -30,10 +31,13 @@ public partial class ActionEditorViewModel : ObservableObject
     [
         new(ActionType.Key, "Key", "⌨️"),
         new(ActionType.Shell, "Shell", "🚀"),
+        new(ActionType.System, "System", "⚙️"),
     ];
 
     public IReadOnlyList<KeyActionDefinition> KeyActionOptions { get; } =
         [.. PieAction.KeyActions, CustomKeyActionOption];
+
+    public IReadOnlyList<SystemActionDefinition> SystemActionOptions { get; } = PieAction.SystemActions;
     public bool HasSelectedAction => SelectedAction != null;
 
     public ActionType SelectedActionType
@@ -59,6 +63,10 @@ public partial class ActionEditorViewModel : ObservableObject
             else if (value == ActionType.Shell)
             {
                 SelectedAction.Parameter = string.Empty;
+            }
+            else if (value == ActionType.System)
+            {
+                _actionDefaultsService.EnsureSystemDefaults(SelectedAction);
             }
 
             OnPropertyChanged();
@@ -98,6 +106,24 @@ public partial class ActionEditorViewModel : ObservableObject
                 {
                     _actionDefaultsService.ApplyKeyDefaults(SelectedAction, definition);
                 }
+            }
+
+            OnPropertyChanged();
+        }
+    }
+
+    public string SelectedSystemActionId
+    {
+        get => SelectedAction?.Parameter ?? string.Empty;
+        set
+        {
+            if (SelectedAction == null || string.IsNullOrEmpty(value) || SelectedAction.Parameter == value)
+                return;
+
+            SelectedAction.Parameter = value;
+            if (PieAction.TryGetSystemAction(SelectedAction.Parameter, out var definition))
+            {
+                _actionDefaultsService.ApplySystemDefaults(SelectedAction, definition);
             }
 
             OnPropertyChanged();
@@ -166,10 +192,12 @@ public partial class ActionEditorViewModel : ObservableObject
         {
             newValue.PropertyChanged += SelectedActionPropertyChanged;
             _actionDefaultsService.EnsureKeyDefaults(newValue);
+            _actionDefaultsService.EnsureSystemDefaults(newValue);
         }
 
         OnPropertyChanged(nameof(SelectedActionType));
         OnPropertyChanged(nameof(SelectedKeyActionId));
+        OnPropertyChanged(nameof(SelectedSystemActionId));
     }
 
     private void SelectedActionPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -178,12 +206,14 @@ public partial class ActionEditorViewModel : ObservableObject
         {
             OnPropertyChanged(nameof(SelectedActionType));
             OnPropertyChanged(nameof(SelectedKeyActionId));
+            OnPropertyChanged(nameof(SelectedSystemActionId));
         }
 
         if (e.PropertyName != nameof(PieAction.Parameter))
             return;
 
         OnPropertyChanged(nameof(SelectedKeyActionId));
+        OnPropertyChanged(nameof(SelectedSystemActionId));
 
         if (SelectedAction == null)
             return;
@@ -196,6 +226,11 @@ public partial class ActionEditorViewModel : ObservableObject
                  PieAction.TryGetKeyAction(SelectedAction.Parameter, out var definition))
         {
             _actionDefaultsService.ApplyKeyDefaults(SelectedAction, definition);
+        }
+        else if (SelectedActionType == ActionType.System &&
+                 PieAction.TryGetSystemAction(SelectedAction.Parameter, out var systemDefinition))
+        {
+            _actionDefaultsService.ApplySystemDefaults(SelectedAction, systemDefinition);
         }
     }
 }


### PR DESCRIPTION
Closes #60

Adds a third action type, **System**, with a curated dropdown of built-in Windows commands, following the existing `KeyActionDefinition` pattern (predefined id + name + icon):

- **Lock** 🔒 - `LockWorkStation`
- **Sleep** 🌙 - `SetSuspendState`
- **Show Desktop** 🖥️ - simulates Win+D via the existing key infrastructure
- **Screenshot** 📸 - simulates Win+Shift+S (snipping overlay)
- **Empty Recycle Bin** 🗑️ - `SHEmptyRecycleBin` (no confirmation prompt; the clear name is the safeguard per the issue)
- **Toggle Dark Mode** 🌓 - flips `AppsUseLightTheme`/`SystemUsesLightTheme` in the registry and broadcasts `WM_SETTINGCHANGE` so apps update immediately

## Design

- `SystemActionDefinition` holds id, name, icon, and an `Execute` delegate; the definitions live in `PieAction.SystemActions` next to `KeyActions`. `Parameter` stores the definition id, so serialization needs no changes.
- Execution lives in the new `SystemActionUtil`; `PieAction.Execute` validates the parameter (not configured / unknown id) before invoking the delegate, so configuration is testable without triggering side effects.
- The editor gets a System entry in the Type dropdown and a system-action combobox, with name/icon defaults applied through `ActionDefaultsService` the same way key and shell defaults are (manual edits are preserved).

## Tests

- Definition sanity: unique ids, non-empty name/icon, non-null execute handler for every system action.
- `CreateSystemAction`/`TryGetSystemAction` behavior including unknown-id fallback.
- Execute validation errors without executing any side effect.
- Defaults application (blank/default/previous-auto values updated, manual names and icons preserved) and unknown-parameter reset.
- Settings JSON round trip with a system action.

All 123 tests pass.