### PR TITLE
Rename the Shell action type to Open

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ For documentation-only changes, explain why build or test commands were skipped.
 - Radial Actions is a lightweight Windows utility opened by a global hotkey. Startup, hotkey registration, tray behavior, and menu display should stay fast and predictable.
 - User-configured actions must not execute during tests, settings load, preview rendering, or validation.
 - Invalid or stale settings should normalize to safe defaults instead of crashing on startup.
-- Shell actions must preserve explicit target, arguments, and working directory behavior.
+- Open actions (formerly Shell) must preserve explicit target, arguments, and working directory behavior.
 - Key actions must accept known media/volume actions and validated custom shortcuts; invalid shortcuts should fail clearly.
 - Update checks must remain controlled by settings and should not introduce surprise network work in deterministic tests.
 

--- a/RadialActions.Tests/Actions/ActionDefaultsServiceTests.cs
+++ b/RadialActions.Tests/Actions/ActionDefaultsServiceTests.cs
@@ -31,7 +31,7 @@ public sealed class ActionDefaultsServiceTests : IDisposable
     }
 
     [Fact]
-    public void ApplyShellDefaults_PreservesManualNameIconAndWorkingDirectory()
+    public void ApplyOpenDefaults_PreservesManualNameIconAndWorkingDirectory()
     {
         Directory.CreateDirectory(_tempRoot);
         var firstRoot = Path.Combine(_tempRoot, "First");
@@ -42,12 +42,12 @@ public sealed class ActionDefaultsServiceTests : IDisposable
         var secondPath = Path.Combine(secondRoot, "Second.exe");
 
         var service = new ActionDefaultsService();
-        var action = PieAction.CreateShellAction("Manual Name", firstPath, "\U0001F6E0\uFE0F", workingDirectory: _tempRoot);
+        var action = PieAction.CreateOpenAction("Manual Name", firstPath, "\U0001F6E0\uFE0F", workingDirectory: _tempRoot);
 
         service.TrackExistingDefaults([action]);
 
         action.Parameter = secondPath;
-        service.ApplyShellDefaults(action, action.Parameter);
+        service.ApplyOpenDefaults(action, action.Parameter);
 
         Assert.Equal("Manual Name", action.Name);
         Assert.Equal("\U0001F6E0\uFE0F", action.Icon);
@@ -55,16 +55,16 @@ public sealed class ActionDefaultsServiceTests : IDisposable
     }
 
     [Fact]
-    public void ApplyShellDefaults_LegacyStarIcon_UpgradesToSelectedDefaultIcon()
+    public void ApplyOpenDefaults_LegacyStarIcon_UpgradesToSelectedDefaultIcon()
     {
         Directory.CreateDirectory(_tempRoot);
         var targetPath = Path.Combine(_tempRoot, "First.exe");
         var service = new ActionDefaultsService();
-        var action = PieAction.CreateShellAction(PieAction.DefaultName, targetPath, ActionDefaultsService.LegacyDefaultIcon);
+        var action = PieAction.CreateOpenAction(PieAction.DefaultName, targetPath, ActionDefaultsService.LegacyDefaultIcon);
 
-        service.ApplyShellDefaults(action, action.Parameter);
+        service.ApplyOpenDefaults(action, action.Parameter);
 
-        Assert.Equal(ShellActionDefaults.FileIcon, action.Icon);
+        Assert.Equal(OpenActionDefaults.FileIcon, action.Icon);
     }
 
     public void Dispose()

--- a/RadialActions.Tests/Actions/ActionDropFactoryTests.cs
+++ b/RadialActions.Tests/Actions/ActionDropFactoryTests.cs
@@ -157,9 +157,9 @@ public sealed class ActionDropFactoryTests : IDisposable
     {
         var action = ActionDropFactory.CreateAction(string.Empty);
 
-        Assert.Equal(ActionType.Shell, action.Type);
+        Assert.Equal(ActionType.Open, action.Type);
         Assert.Equal(PieAction.DefaultName, action.Name);
-        Assert.Equal(ShellActionDefaults.FileIcon, action.Icon);
+        Assert.Equal(OpenActionDefaults.FileIcon, action.Icon);
     }
 
     [Fact]
@@ -167,10 +167,10 @@ public sealed class ActionDropFactoryTests : IDisposable
     {
         var action = ActionDropFactory.CreateAction("https://example.com/path");
 
-        Assert.Equal(ActionType.Shell, action.Type);
+        Assert.Equal(ActionType.Open, action.Type);
         Assert.Equal("https://example.com/path", action.Parameter);
         Assert.Equal("example.com", action.Name);
-        Assert.Equal(ShellActionDefaults.WebIcon, action.Icon);
+        Assert.Equal(OpenActionDefaults.WebIcon, action.Icon);
         Assert.Equal(string.Empty, action.WorkingDirectory);
     }
 
@@ -183,10 +183,10 @@ public sealed class ActionDropFactoryTests : IDisposable
 
         var action = ActionDropFactory.CreateAction(folder);
 
-        Assert.Equal(ActionType.Shell, action.Type);
+        Assert.Equal(ActionType.Open, action.Type);
         Assert.Equal(folder, action.Parameter);
         Assert.Equal("Games", action.Name);
-        Assert.Equal(ShellActionDefaults.FolderIcon, action.Icon);
+        Assert.Equal(OpenActionDefaults.FolderIcon, action.Icon);
         Assert.Equal(folder, action.WorkingDirectory);
     }
 
@@ -199,10 +199,10 @@ public sealed class ActionDropFactoryTests : IDisposable
 
         var action = ActionDropFactory.CreateAction(file);
 
-        Assert.Equal(ActionType.Shell, action.Type);
+        Assert.Equal(ActionType.Open, action.Type);
         Assert.Equal(file, action.Parameter);
         Assert.Equal("Notes", action.Name);
-        Assert.Equal(ShellActionDefaults.FileIcon, action.Icon);
+        Assert.Equal(OpenActionDefaults.FileIcon, action.Icon);
         Assert.Equal(_tempRoot, action.WorkingDirectory);
     }
 

--- a/RadialActions.Tests/Actions/ActionsSettingsViewModelTests.cs
+++ b/RadialActions.Tests/Actions/ActionsSettingsViewModelTests.cs
@@ -81,7 +81,7 @@ public sealed class ActionsSettingsViewModelTests
         var addedA = viewModel.Actions[2];
         var addedB = viewModel.Actions[3];
         Assert.Equal([first, second, addedA, addedB, third], viewModel.Actions);
-        Assert.Equal(ActionType.Shell, addedA.Type);
+        Assert.Equal(ActionType.Open, addedA.Type);
         Assert.Equal("https://a.com", addedA.Parameter);
         Assert.Equal("https://b.com", addedB.Parameter);
         Assert.Same(addedB, viewModel.SelectedAction);
@@ -121,7 +121,7 @@ public sealed class ActionsSettingsViewModelTests
     {
         var viewModel = new ActionEditorViewModel(new ActionDefaultsService(), []);
 
-        Assert.Equal([ActionType.Key, ActionType.Shell], viewModel.ActionTypes.Select(option => option.Type));
+        Assert.Equal([ActionType.Key, ActionType.Open], viewModel.ActionTypes.Select(option => option.Type));
     }
 
     [Fact]

--- a/RadialActions.Tests/Actions/OpenActionDefaultsTests.cs
+++ b/RadialActions.Tests/Actions/OpenActionDefaultsTests.cs
@@ -1,21 +1,21 @@
 namespace RadialActions.Tests;
 
-public sealed class ShellActionDefaultsTests : IDisposable
+public sealed class OpenActionDefaultsTests : IDisposable
 {
     private readonly string _tempRoot = Path.Combine(Path.GetTempPath(), "RadialActions.Tests", Guid.NewGuid().ToString("N"));
 
     [Fact]
     public void GetDefaults_EmptyTarget_ReturnsNull()
     {
-        Assert.Null(ShellActionDefaults.FromTarget(string.Empty));
+        Assert.Null(OpenActionDefaults.FromTarget(string.Empty));
     }
 
     [Fact]
     public void GetDefaults_Url_UsesHostNameAndWebIcon()
     {
-        var defaults = ShellActionDefaults.FromTarget("https://docs.github.com/en");
+        var defaults = OpenActionDefaults.FromTarget("https://docs.github.com/en");
 
-        Assert.Equal(new ShellActionDefaults("docs.github.com", ShellActionDefaults.WebIcon, string.Empty), defaults);
+        Assert.Equal(new OpenActionDefaults("docs.github.com", OpenActionDefaults.WebIcon, string.Empty), defaults);
     }
 
     [Fact]
@@ -25,9 +25,9 @@ public sealed class ShellActionDefaultsTests : IDisposable
         var filePath = Path.Combine(_tempRoot, "Example App.exe");
         File.WriteAllText(filePath, "test");
 
-        var defaults = ShellActionDefaults.FromTarget(filePath);
+        var defaults = OpenActionDefaults.FromTarget(filePath);
 
-        Assert.Equal(new ShellActionDefaults("Example App", ShellActionDefaults.FileIcon, _tempRoot), defaults);
+        Assert.Equal(new OpenActionDefaults("Example App", OpenActionDefaults.FileIcon, _tempRoot), defaults);
     }
 
     [Fact]
@@ -36,9 +36,9 @@ public sealed class ShellActionDefaultsTests : IDisposable
         var folderPath = Path.Combine(_tempRoot, "Docs");
         Directory.CreateDirectory(folderPath);
 
-        var defaults = ShellActionDefaults.FromTarget(new Uri(folderPath).AbsoluteUri);
+        var defaults = OpenActionDefaults.FromTarget(new Uri(folderPath).AbsoluteUri);
 
-        Assert.Equal(new ShellActionDefaults("Docs", ShellActionDefaults.FolderIcon, folderPath), defaults);
+        Assert.Equal(new OpenActionDefaults("Docs", OpenActionDefaults.FolderIcon, folderPath), defaults);
     }
 
     public void Dispose()

--- a/RadialActions.Tests/Actions/PieActionTests.cs
+++ b/RadialActions.Tests/Actions/PieActionTests.cs
@@ -15,11 +15,11 @@ public class PieActionTests
     }
 
     [Fact]
-    public void CreateShellAction_SetsExpectedFields()
+    public void CreateOpenAction_SetsExpectedFields()
     {
-        var action = PieAction.CreateShellAction("Docs", "https://example.com", "*", "--foo", "C:\\");
+        var action = PieAction.CreateOpenAction("Docs", "https://example.com", "*", "--foo", "C:\\");
 
-        Assert.Equal(ActionType.Shell, action.Type);
+        Assert.Equal(ActionType.Open, action.Type);
         Assert.True(action.IsEnabled);
         Assert.Equal("Docs", action.Name);
         Assert.Equal("*", action.Icon);
@@ -59,9 +59,9 @@ public class PieActionTests
     }
 
     [Fact]
-    public void Execute_ShellActionWithoutTarget_ThrowsInvalidOperationException()
+    public void Execute_OpenActionWithoutTarget_ThrowsInvalidOperationException()
     {
-        var action = PieAction.CreateShellAction("Docs", string.Empty);
+        var action = PieAction.CreateOpenAction("Docs", string.Empty);
 
         var ex = Assert.Throws<InvalidOperationException>(() => action.Execute());
 

--- a/RadialActions.Tests/Settings/SettingsSerializationTests.cs
+++ b/RadialActions.Tests/Settings/SettingsSerializationTests.cs
@@ -69,7 +69,7 @@ public class SettingsSerializationTests
         settings.Actions = new System.Collections.ObjectModel.ObservableCollection<PieAction>
         {
             PieAction.CreateKeyAction("Mute"),
-            PieAction.CreateShellAction("Explorer", "explorer.exe")
+            PieAction.CreateOpenAction("Explorer", "explorer.exe")
         };
         settings.Actions[1].IsEnabled = false;
 
@@ -83,7 +83,7 @@ public class SettingsSerializationTests
         Assert.Equal(ActionType.Key, loaded.Actions[0].Type);
         Assert.Equal("Mute", loaded.Actions[0].Parameter);
         Assert.True(loaded.Actions[0].IsEnabled);
-        Assert.Equal(ActionType.Shell, loaded.Actions[1].Type);
+        Assert.Equal(ActionType.Open, loaded.Actions[1].Type);
         Assert.Equal("explorer.exe", loaded.Actions[1].Parameter);
         Assert.False(loaded.Actions[1].IsEnabled);
     }

--- a/RadialActions/Actions/Action.cs
+++ b/RadialActions/Actions/Action.cs
@@ -20,9 +20,9 @@ public enum ActionType
     Key = 1,
 
     /// <summary>
-    /// Launch an app, open a file, or open a URL using shell execution.
+    /// Open an app, file, folder, or URL using shell execution.
     /// </summary>
-    Shell = 2,
+    Open = 2,
 }
 
 /// <summary>
@@ -114,13 +114,13 @@ public partial class PieAction : ObservableObject
     private string _parameter = string.Empty;
 
     /// <summary>
-    /// Additional arguments for shell actions.
+    /// Additional arguments for Open actions.
     /// </summary>
     [ObservableProperty]
     private string _arguments = string.Empty;
 
     /// <summary>
-    /// Optional working directory for shell actions.
+    /// Optional working directory for Open actions.
     /// </summary>
     [ObservableProperty]
     private string _workingDirectory = string.Empty;
@@ -157,12 +157,12 @@ public partial class PieAction : ObservableObject
     }
 
     /// <summary>
-    /// Creates a shell action.
+    /// Creates an Open action.
     /// </summary>
-    public static PieAction CreateShellAction(string name, string target, string icon = "📁", string arguments = "", string workingDirectory = "")
+    public static PieAction CreateOpenAction(string name, string target, string icon = "📁", string arguments = "", string workingDirectory = "")
         => new(name, icon)
         {
-            Type = ActionType.Shell,
+            Type = ActionType.Open,
             Parameter = target,
             Arguments = arguments,
             WorkingDirectory = workingDirectory
@@ -182,8 +182,8 @@ public partial class PieAction : ObservableObject
             case ActionType.Key:
                 ExecuteKey();
                 return;
-            case ActionType.Shell:
-                ExecuteShell();
+            case ActionType.Open:
+                ExecuteOpen();
                 return;
             default:
                 throw new NotSupportedException("Action type is not supported");
@@ -207,7 +207,7 @@ public partial class PieAction : ObservableObject
         ActionUtil.SimulateKeyboardShortcut(Parameter);
     }
 
-    private void ExecuteShell()
+    private void ExecuteOpen()
     {
         if (string.IsNullOrWhiteSpace(Parameter))
             throw new InvalidOperationException("Launch target not configured");

--- a/RadialActions/Actions/ActionDefaultsService.cs
+++ b/RadialActions/Actions/ActionDefaultsService.cs
@@ -5,20 +5,20 @@ public sealed class ActionDefaultsService
     public const string LegacyDefaultIcon = "\u2B50";
 
     private readonly Dictionary<PieAction, KeyActionDefinition> _autoKeyDefaults = [];
-    private readonly Dictionary<PieAction, ShellActionDefaults> _autoShellDefaults = [];
+    private readonly Dictionary<PieAction, OpenActionDefaults> _autoOpenDefaults = [];
 
-    public ShellActionDefaults? GetShellDefaults(string target) => ShellActionDefaults.FromTarget(target);
+    public OpenActionDefaults? GetOpenDefaults(string target) => OpenActionDefaults.FromTarget(target);
 
     public void Forget(PieAction action)
     {
         _autoKeyDefaults.Remove(action);
-        _autoShellDefaults.Remove(action);
+        _autoOpenDefaults.Remove(action);
     }
 
     public void TrackExistingDefaults(IEnumerable<PieAction> actions)
     {
         _autoKeyDefaults.Clear();
-        _autoShellDefaults.Clear();
+        _autoOpenDefaults.Clear();
 
         foreach (var action in actions)
         {
@@ -29,12 +29,12 @@ public sealed class ActionDefaultsService
                     _autoKeyDefaults[action] = definition;
                 }
             }
-            else if (action.Type == ActionType.Shell)
+            else if (action.Type == ActionType.Open)
             {
-                var defaults = GetShellDefaults(action.Parameter);
+                var defaults = GetOpenDefaults(action.Parameter);
                 if (defaults.HasValue)
                 {
-                    _autoShellDefaults[action] = defaults.Value;
+                    _autoOpenDefaults[action] = defaults.Value;
                 }
             }
         }
@@ -69,16 +69,16 @@ public sealed class ActionDefaultsService
         _autoKeyDefaults[action] = definition;
     }
 
-    public void ApplyShellDefaults(PieAction action, string target)
+    public void ApplyOpenDefaults(PieAction action, string target)
     {
-        if (action.Type != ActionType.Shell)
+        if (action.Type != ActionType.Open)
             return;
 
-        var defaults = GetShellDefaults(target);
+        var defaults = GetOpenDefaults(target);
         if (!defaults.HasValue)
             return;
 
-        _autoShellDefaults.TryGetValue(action, out var previous);
+        _autoOpenDefaults.TryGetValue(action, out var previous);
         var next = defaults.Value;
 
         if (ShouldApplyDefault(action.Name, PieAction.DefaultName, previous.Name ?? string.Empty))
@@ -98,7 +98,7 @@ public sealed class ActionDefaultsService
             action.WorkingDirectory = next.WorkingDirectory;
         }
 
-        _autoShellDefaults[action] = next;
+        _autoOpenDefaults[action] = next;
     }
 
     private static bool ShouldApplyDefault(string currentValue, string defaultValue, string previousValue)

--- a/RadialActions/Actions/ActionDropFactory.cs
+++ b/RadialActions/Actions/ActionDropFactory.cs
@@ -5,7 +5,7 @@ using System.Windows;
 namespace RadialActions;
 
 /// <summary>
-/// Turns data dropped onto the actions list (files, folders, apps, or links) into prefilled shell actions.
+/// Turns data dropped onto the actions list (files, folders, apps, or links) into prefilled Open actions.
 /// </summary>
 public static class ActionDropFactory
 {
@@ -57,14 +57,14 @@ public static class ActionDropFactory
     }
 
     /// <summary>
-    /// Builds a shell action for a single dropped target, prefilling its name, icon, and working directory from <see cref="ShellActionDefaults"/>.
+    /// Builds an Open action for a single dropped target, prefilling its name, icon, and working directory from <see cref="OpenActionDefaults"/>.
     /// </summary>
     public static PieAction CreateAction(string target)
     {
-        var defaults = ShellActionDefaults.FromTarget(target)
-            ?? new ShellActionDefaults(PieAction.DefaultName, ShellActionDefaults.FileIcon, string.Empty);
+        var defaults = OpenActionDefaults.FromTarget(target)
+            ?? new OpenActionDefaults(PieAction.DefaultName, OpenActionDefaults.FileIcon, string.Empty);
 
-        return PieAction.CreateShellAction(defaults.Name, target, defaults.Icon, workingDirectory: defaults.WorkingDirectory);
+        return PieAction.CreateOpenAction(defaults.Name, target, defaults.Icon, workingDirectory: defaults.WorkingDirectory);
     }
 
     // Reads the most specific link text the drop advertises, preferring the dedicated URL formats over plain text.

--- a/RadialActions/Actions/OpenActionDefaults.cs
+++ b/RadialActions/Actions/OpenActionDefaults.cs
@@ -2,13 +2,13 @@ using System.IO;
 
 namespace RadialActions;
 
-public readonly record struct ShellActionDefaults(string Name, string Icon, string WorkingDirectory)
+public readonly record struct OpenActionDefaults(string Name, string Icon, string WorkingDirectory)
 {
     public const string WebIcon = "\U0001F310";
     public const string FolderIcon = "\U0001F4C2";
     public const string FileIcon = "\U0001F4C1";
 
-    public static ShellActionDefaults? FromTarget(string target)
+    public static OpenActionDefaults? FromTarget(string target)
     {
         if (string.IsNullOrWhiteSpace(target))
             return null;
@@ -21,13 +21,13 @@ public readonly record struct ShellActionDefaults(string Name, string Icon, stri
             }
 
             var name = string.IsNullOrWhiteSpace(uri.Host) ? uri.AbsoluteUri : uri.Host;
-            return new ShellActionDefaults(name, WebIcon, string.Empty);
+            return new OpenActionDefaults(name, WebIcon, string.Empty);
         }
 
         return FromPath(target);
     }
 
-    private static ShellActionDefaults FromPath(string path)
+    private static OpenActionDefaults FromPath(string path)
     {
         var isDirectory = Directory.Exists(path);
         var name = Path.GetFileNameWithoutExtension(path);
@@ -44,6 +44,6 @@ public readonly record struct ShellActionDefaults(string Name, string Icon, stri
         var icon = isDirectory ? FolderIcon : FileIcon;
         var workingDirectory = isDirectory ? path : Path.GetDirectoryName(path) ?? string.Empty;
 
-        return new ShellActionDefaults(name, icon, workingDirectory);
+        return new OpenActionDefaults(name, icon, workingDirectory);
     }
 }

--- a/RadialActions/Properties/Settings.cs
+++ b/RadialActions/Properties/Settings.cs
@@ -69,7 +69,7 @@ public sealed partial class Settings
             PieAction.CreateKeyAction("PreviousTrack"),
             PieAction.CreateKeyAction("NextTrack"),
             PieAction.CreateKeyAction("Mute"),
-            PieAction.CreateShellAction("File Explorer", "explorer.exe", "📁"),
+            PieAction.CreateOpenAction("File Explorer", "explorer.exe", "📁"),
         ];
     }
 

--- a/RadialActions/Settings/ActionEditorView.xaml
+++ b/RadialActions/Settings/ActionEditorView.xaml
@@ -51,7 +51,7 @@
                 </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>
-        <TextBlock Text="Use Key for shortcuts and media controls; Shell for apps, files, folders, URLs, or commands."
+        <TextBlock Text="Use Key for shortcuts and media controls; Open for apps, files, folders, URLs, or commands."
                    Style="{StaticResource DescriptionTextBlock}" />
 
         <StackPanel Margin="0,0,0,4"
@@ -105,7 +105,7 @@
         </StackPanel>
 
         <StackPanel
-              Visibility="{Binding SelectedActionType, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionType.Shell}}">
+              Visibility="{Binding SelectedActionType, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionType.Open}}">
             <TextBlock Text="Target:"
                        Style="{StaticResource ActionEditorLabelTextBlock}" />
             <Grid>
@@ -118,7 +118,7 @@
                          Text="{Binding SelectedAction.Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <Button Grid.Column="2"
                         Content="Browse..."
-                        Command="{Binding BrowseShellTargetCommand}"
+                        Command="{Binding BrowseOpenTargetCommand}"
                         Padding="8,2" />
             </Grid>
             <TextBlock Text="Choose the app, file, folder, URL, or command to open."

--- a/RadialActions/Settings/ActionEditorViewModel.cs
+++ b/RadialActions/Settings/ActionEditorViewModel.cs
@@ -34,7 +34,7 @@ public partial class ActionEditorViewModel : ObservableObject
     public IReadOnlyList<ActionTypeOption> ActionTypes { get; } =
     [
         new(ActionType.Key, "Key", "⌨️"),
-        new(ActionType.Shell, "Shell", "🚀"),
+        new(ActionType.Open, "Open", "🚀"),
     ];
 
     public IReadOnlyList<KeyActionDefinition> KeyActionOptions { get; } =
@@ -67,7 +67,7 @@ public partial class ActionEditorViewModel : ObservableObject
             {
                 _actionDefaultsService.EnsureKeyDefaults(SelectedAction);
             }
-            else if (value == ActionType.Shell)
+            else if (value == ActionType.Open)
             {
                 SelectedAction.Parameter = string.Empty;
             }
@@ -121,7 +121,7 @@ public partial class ActionEditorViewModel : ObservableObject
     }
 
     [RelayCommand]
-    private void BrowseShellTarget()
+    private void BrowseOpenTarget()
     {
         if (SelectedAction == null)
             return;
@@ -150,7 +150,7 @@ public partial class ActionEditorViewModel : ObservableObject
             Title = "Select a working directory"
         };
 
-        var suggested = _actionDefaultsService.GetShellDefaults(SelectedAction.Parameter)?.WorkingDirectory;
+        var suggested = _actionDefaultsService.GetOpenDefaults(SelectedAction.Parameter)?.WorkingDirectory;
         if (!string.IsNullOrWhiteSpace(SelectedAction.WorkingDirectory))
         {
             dialog.InitialDirectory = SelectedAction.WorkingDirectory;
@@ -199,9 +199,9 @@ public partial class ActionEditorViewModel : ObservableObject
         if (SelectedAction == null)
             return;
 
-        if (SelectedActionType == ActionType.Shell)
+        if (SelectedActionType == ActionType.Open)
         {
-            _actionDefaultsService.ApplyShellDefaults(SelectedAction, SelectedAction.Parameter);
+            _actionDefaultsService.ApplyOpenDefaults(SelectedAction, SelectedAction.Parameter);
         }
         else if (SelectedActionType == ActionType.Key &&
                  PieAction.TryGetKeyAction(SelectedAction.Parameter, out var definition))


### PR DESCRIPTION
## Summary

Renames the user-facing action type **Shell → Open** across the UI and the code, with no behavior change.

## Why

"Shell" is developer jargon. What the action actually does is *open* something: an app, file, folder, or URL. The editor's own hint text already describes it that way ("Choose the app, file, folder, URL, or command to open"), and "Open" matches standard Windows vocabulary. This is a naming-clarity change only.

We deliberately did **not** add a toggle for `UseShellExecute`. That is a `ProcessStartInfo` implementation detail, not a user-meaningful choice — turning it off would break URLs, folders, and file-association launches while exposing nothing users need. If a "run a raw command line" scenario ever comes up, it belongs as its own distinct action type, not a boolean named after a .NET property.

## What changed

- `ActionType.Shell` → `ActionType.Open` (enum member).
- Dropdown label and editor hint text now say **Open**.
- Internal identifiers renamed for consistency: `CreateShellAction` → `CreateOpenAction`, `ShellActionDefaults` → `OpenActionDefaults` (file renamed), `ApplyShellDefaults`/`GetShellDefaults`/`_autoShellDefaults` → `Open*`, `ExecuteShell` → `ExecuteOpen`, `BrowseShellTarget` → `BrowseOpenTarget`.
- Tests and `AGENTS.md` updated to match.
- `UseShellExecute = true` in the launch code is unchanged — that is the .NET API, not the feature name.

## Compatibility

Settings serialize `Type` as an integer (`Open` is still `2`), so existing saved configurations load unchanged. No migration needed.

## Testing

- `dotnet build RadialActions.sln`
- `dotnet test RadialActions.sln`
