### PR TITLE
Add a Script action type for running inline PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Radial Actions is a free Windows app that opens with a global hotkey. It gives y
 
 - **Instant access:** summon the menu anywhere with a global hotkey (`Ctrl+Alt+Space` by default, fully customizable). It opens at your cursor, or in the center of the screen if you prefer.
 - **Launch anything:** apps, files, folders, and websites, with optional arguments and working directory.
+- **Run PowerShell scripts:** write a script right in the action and run it on click, optionally hidden with no console window.
 - **Media & volume controls:** play/pause, next/previous track, mute, and volume up/down from any app.
 - **Custom keyboard shortcuts:** assign any key combo to a slice and trigger it with a click.
 - **Make it yours:** name each slice, pick an emoji icon, resize the menu, and drag slices to reorder them.

--- a/RadialActions.Tests/Actions/ActionsSettingsViewModelTests.cs
+++ b/RadialActions.Tests/Actions/ActionsSettingsViewModelTests.cs
@@ -121,7 +121,40 @@ public sealed class ActionsSettingsViewModelTests
     {
         var viewModel = new ActionEditorViewModel(new ActionDefaultsService(), []);
 
-        Assert.Equal([ActionType.Key, ActionType.Open], viewModel.ActionTypes.Select(option => option.Type));
+        Assert.Equal([ActionType.Key, ActionType.Open, ActionType.Script], viewModel.ActionTypes.Select(option => option.Type));
+    }
+
+    [Fact]
+    public void SelectedActionType_SwitchingToScript_DefaultsInterpreterAndRunHidden()
+    {
+        var action = PieAction.CreateOpenAction("Explorer", "explorer.exe");
+        var viewModel = new ActionEditorViewModel(new ActionDefaultsService(), [action])
+        {
+            SelectedAction = action
+        };
+
+        viewModel.SelectedActionType = ActionType.Script;
+
+        Assert.Equal(ActionType.Script, action.Type);
+        Assert.Equal(PieAction.DefaultScriptInterpreter, action.Parameter);
+        Assert.True(action.RunHidden);
+    }
+
+    [Fact]
+    public void SelectedActionType_ReturningToScript_PreservesRunHiddenChoice()
+    {
+        var action = PieAction.CreateScriptAction("Backup", "Get-Date", runHidden: true);
+        var viewModel = new ActionEditorViewModel(new ActionDefaultsService(), [action])
+        {
+            SelectedAction = action
+        };
+        action.RunHidden = false; // user unchecks Run hidden
+
+        viewModel.SelectedActionType = ActionType.Open;
+        viewModel.SelectedActionType = ActionType.Script;
+
+        Assert.Equal(ActionType.Script, action.Type);
+        Assert.False(action.RunHidden); // choice preserved, not re-defaulted to hidden
     }
 
     [Fact]

--- a/RadialActions.Tests/Actions/PieActionTests.cs
+++ b/RadialActions.Tests/Actions/PieActionTests.cs
@@ -29,6 +29,40 @@ public class PieActionTests
     }
 
     [Fact]
+    public void CreateScriptAction_SetsExpectedFields()
+    {
+        var action = PieAction.CreateScriptAction("Backup", "Get-Date", "📜", "pwsh.exe", "C:\\Scripts", runHidden: true);
+
+        Assert.Equal(ActionType.Script, action.Type);
+        Assert.True(action.IsEnabled);
+        Assert.Equal("Backup", action.Name);
+        Assert.Equal("📜", action.Icon);
+        Assert.Equal("pwsh.exe", action.Parameter);
+        Assert.Equal("Get-Date", action.Script);
+        Assert.Equal("C:\\Scripts", action.WorkingDirectory);
+        Assert.True(action.RunHidden);
+    }
+
+    [Fact]
+    public void CreateScriptAction_DefaultsRunHiddenToFalse()
+    {
+        var action = PieAction.CreateScriptAction("Backup", "Get-Date");
+
+        Assert.False(action.RunHidden);
+    }
+
+    [Fact]
+    public void EncodePowerShellCommand_RoundTripsAsUtf16LeBase64()
+    {
+        const string script = "Write-Host 'héllo'\r\nGet-Date";
+
+        var encoded = PieAction.EncodePowerShellCommand(script);
+        var decoded = System.Text.Encoding.Unicode.GetString(Convert.FromBase64String(encoded));
+
+        Assert.Equal(script, decoded);
+    }
+
+    [Fact]
     public void TryGetKeyAction_KnownId_ReturnsDefinition()
     {
         var ok = PieAction.TryGetKeyAction("PlayPause", out var definition);
@@ -66,6 +100,26 @@ public class PieActionTests
         var ex = Assert.Throws<InvalidOperationException>(() => action.Execute());
 
         Assert.Equal("Launch target not configured", ex.Message);
+    }
+
+    [Fact]
+    public void Execute_ScriptActionWithoutScript_ThrowsInvalidOperationException()
+    {
+        var action = PieAction.CreateScriptAction("Backup", string.Empty);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => action.Execute());
+
+        Assert.Equal("Script is empty", ex.Message);
+    }
+
+    [Fact]
+    public void Execute_ScriptTooLong_ThrowsInvalidOperationException()
+    {
+        var action = PieAction.CreateScriptAction("Big", new string('a', 20000));
+
+        var ex = Assert.Throws<InvalidOperationException>(() => action.Execute());
+
+        Assert.Equal("Script is too long to run", ex.Message);
     }
 
     [Fact]

--- a/RadialActions.Tests/Settings/SettingsSerializationTests.cs
+++ b/RadialActions.Tests/Settings/SettingsSerializationTests.cs
@@ -89,6 +89,50 @@ public class SettingsSerializationTests
     }
 
     [Fact]
+    public void SerializeToJson_RoundTripsScriptAction()
+    {
+        var settings = Settings.DeserializeFromJson("{}");
+        settings.Actions = new System.Collections.ObjectModel.ObservableCollection<PieAction>
+        {
+            PieAction.CreateScriptAction("Backup", "Get-Date | Out-File $env:TEMP\\now.txt", "📜", "pwsh.exe", "C:\\Scripts", runHidden: true)
+        };
+
+        var json = settings.SerializeToJson();
+        var loaded = Settings.DeserializeFromJson(json);
+
+        Assert.Single(loaded.Actions);
+        Assert.Equal(ActionType.Script, loaded.Actions[0].Type);
+        Assert.Equal("pwsh.exe", loaded.Actions[0].Parameter);
+        Assert.Equal("Get-Date | Out-File $env:TEMP\\now.txt", loaded.Actions[0].Script);
+        Assert.Equal("C:\\Scripts", loaded.Actions[0].WorkingDirectory);
+        Assert.True(loaded.Actions[0].RunHidden);
+    }
+
+    [Fact]
+    public void DeserializeFromJson_ScriptActionMissingRunHidden_DefaultsToFalse()
+    {
+        const string json = """
+        {
+          "Actions": [
+            {
+              "Name": "Backup",
+              "Icon": "*",
+              "Type": 3,
+              "Script": "Get-Date"
+            }
+          ]
+        }
+        """;
+
+        var settings = Settings.DeserializeFromJson(json);
+
+        Assert.Single(settings.Actions);
+        Assert.Equal(ActionType.Script, settings.Actions[0].Type);
+        Assert.Equal("Get-Date", settings.Actions[0].Script);
+        Assert.False(settings.Actions[0].RunHidden);
+    }
+
+    [Fact]
     public void DeserializeFromJson_MissingIsEnabled_DefaultsToTrue()
     {
         const string json = """

--- a/RadialActions/Actions/Action.cs
+++ b/RadialActions/Actions/Action.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.IO;
+using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace RadialActions;
@@ -23,6 +24,11 @@ public enum ActionType
     /// Open an app, file, folder, or URL using shell execution.
     /// </summary>
     Open = 2,
+
+    /// <summary>
+    /// Run an inline PowerShell script, optionally without a console window.
+    /// </summary>
+    Script = 3,
 }
 
 /// <summary>
@@ -53,6 +59,7 @@ public partial class PieAction : ObservableObject
 {
     public const string DefaultName = "New Action";
     public const string DefaultIcon = "⚡";
+    public const string DefaultScriptInterpreter = "powershell.exe";
 
     public const string MediaCategory = "Media";
     public const string VolumeCategory = "Volume";
@@ -126,6 +133,18 @@ public partial class PieAction : ObservableObject
     private string _workingDirectory = string.Empty;
 
     /// <summary>
+    /// The inline script body for Script actions.
+    /// </summary>
+    [ObservableProperty]
+    private string _script = string.Empty;
+
+    /// <summary>
+    /// For Script actions, runs the interpreter without showing a console window.
+    /// </summary>
+    [ObservableProperty]
+    private bool _runHidden;
+
+    /// <summary>
     /// Creates a new empty action.
     /// </summary>
     public PieAction() { }
@@ -169,6 +188,19 @@ public partial class PieAction : ObservableObject
         };
 
     /// <summary>
+    /// Creates a script action.
+    /// </summary>
+    public static PieAction CreateScriptAction(string name, string script, string icon = DefaultIcon, string interpreter = "", string workingDirectory = "", bool runHidden = false)
+        => new(name, icon)
+        {
+            Type = ActionType.Script,
+            Parameter = interpreter,
+            Script = script,
+            WorkingDirectory = workingDirectory,
+            RunHidden = runHidden
+        };
+
+    /// <summary>
     /// Executes the action.
     /// </summary>
     public void Execute()
@@ -184,6 +216,9 @@ public partial class PieAction : ObservableObject
                 return;
             case ActionType.Open:
                 ExecuteOpen();
+                return;
+            case ActionType.Script:
+                ExecuteScript();
                 return;
             default:
                 throw new NotSupportedException("Action type is not supported");
@@ -225,6 +260,39 @@ public partial class PieAction : ObservableObject
 
         Process.Start(psi);
     }
+
+    private void ExecuteScript()
+    {
+        if (string.IsNullOrWhiteSpace(Script))
+            throw new InvalidOperationException("Script is empty");
+
+        var interpreter = string.IsNullOrWhiteSpace(Parameter) ? DefaultScriptInterpreter : Parameter;
+        var arguments = $"-NoProfile -ExecutionPolicy Bypass -EncodedCommand {EncodePowerShellCommand(Script)}";
+
+        // The whole command line must fit CreateProcess's 32,767 character limit; fail with a clear message instead of an opaque OS error.
+        if (interpreter.Length + 1 + arguments.Length >= 32000)
+            throw new InvalidOperationException("Script is too long to run");
+
+        // UseShellExecute must be false so CreateNoWindow can suppress the console window for hidden scripts.
+        // The body is passed as a Base64-encoded command so multiline scripts, quotes, and newlines need no escaping and no temp file.
+        var psi = new ProcessStartInfo(interpreter)
+        {
+            UseShellExecute = false,
+            CreateNoWindow = RunHidden,
+            Arguments = arguments
+        };
+
+        if (!string.IsNullOrWhiteSpace(WorkingDirectory))
+        {
+            psi.WorkingDirectory = WorkingDirectory;
+        }
+
+        using var process = Process.Start(psi);
+    }
+
+    // PowerShell -EncodedCommand expects Base64 of the UTF-16LE bytes of the script.
+    internal static string EncodePowerShellCommand(string script)
+        => Convert.ToBase64String(Encoding.Unicode.GetBytes(script ?? string.Empty));
 
     public override string ToString() => Name;
 }

--- a/RadialActions/Properties/Settings.cs
+++ b/RadialActions/Properties/Settings.cs
@@ -102,6 +102,7 @@ public sealed partial class Settings
             action.Parameter ??= string.Empty;
             action.Arguments ??= string.Empty;
             action.WorkingDirectory ??= string.Empty;
+            action.Script ??= string.Empty;
 
             if (!Enum.IsDefined(typeof(ActionType), action.Type))
             {

--- a/RadialActions/Settings/ActionEditorView.xaml
+++ b/RadialActions/Settings/ActionEditorView.xaml
@@ -51,7 +51,7 @@
                 </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>
-        <TextBlock Text="Use Key for shortcuts and media controls; Open for apps, files, folders, URLs, or commands."
+        <TextBlock Text="Use Key for shortcuts and media controls, Open for apps, files, folders, or URLs, and Script to run PowerShell."
                    Style="{StaticResource DescriptionTextBlock}" />
 
         <StackPanel Margin="0,0,0,4"
@@ -146,6 +146,54 @@
                         Padding="8,2" />
             </Grid>
             <TextBlock Text="Optional folder to use as the target's start location."
+                       Style="{StaticResource DescriptionTextBlock}" />
+        </StackPanel>
+
+        <StackPanel
+              Visibility="{Binding SelectedActionType, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionType.Script}}">
+            <TextBlock Text="Script:"
+                       Style="{StaticResource ActionEditorLabelTextBlock}" />
+            <TextBox Text="{Binding SelectedAction.Script, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                     AcceptsReturn="True"
+                     AcceptsTab="True"
+                     TextWrapping="NoWrap"
+                     FontFamily="Consolas, Cascadia Mono, Courier New, monospace"
+                     MinHeight="150"
+                     MaxHeight="320"
+                     VerticalContentAlignment="Top"
+                     VerticalScrollBarVisibility="Auto"
+                     HorizontalScrollBarVisibility="Auto" />
+            <TextBlock Text="Runs when the slice is clicked. No separate file needed, for example: Get-Date | Out-File $env:TEMP\now.txt"
+                       Style="{StaticResource DescriptionTextBlock}" />
+
+            <TextBlock Text="Run With:"
+                       Style="{StaticResource ActionEditorLabelTextBlock}" />
+            <TextBox Text="{Binding SelectedAction.Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            <TextBlock Text="The PowerShell to run the script with: powershell.exe (default), or pwsh.exe for PowerShell 7."
+                       Style="{StaticResource DescriptionTextBlock}" />
+
+            <TextBlock Text="Working Directory:"
+                       Style="{StaticResource ActionEditorLabelTextBlock}" />
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="6" />
+                    <ColumnDefinition Width="Auto" />
+                </Grid.ColumnDefinitions>
+                <TextBox Grid.Column="0"
+                         Text="{Binding SelectedAction.WorkingDirectory, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                <Button Grid.Column="2"
+                        Content="Browse..."
+                        Command="{Binding BrowseWorkingDirectoryCommand}"
+                        Padding="8,2" />
+            </Grid>
+            <TextBlock Text="Optional folder to run the script in."
+                       Style="{StaticResource DescriptionTextBlock}" />
+
+            <CheckBox Content="Run hidden"
+                      Margin="0,8,0,0"
+                      IsChecked="{Binding SelectedAction.RunHidden, Mode=TwoWay}" />
+            <TextBlock Text="Run without showing a console window."
                        Style="{StaticResource DescriptionTextBlock}" />
         </StackPanel>
     </StackPanel>

--- a/RadialActions/Settings/ActionEditorViewModel.cs
+++ b/RadialActions/Settings/ActionEditorViewModel.cs
@@ -35,6 +35,7 @@ public partial class ActionEditorViewModel : ObservableObject
     [
         new(ActionType.Key, "Key", "⌨️"),
         new(ActionType.Open, "Open", "🚀"),
+        new(ActionType.Script, "Script", "📜"),
     ];
 
     public IReadOnlyList<KeyActionDefinition> KeyActionOptions { get; } =
@@ -62,6 +63,8 @@ public partial class ActionEditorViewModel : ObservableObject
                 SelectedAction.Parameter = string.Empty;
                 SelectedAction.Arguments = string.Empty;
                 SelectedAction.WorkingDirectory = string.Empty;
+                SelectedAction.Script = string.Empty;
+                SelectedAction.RunHidden = false;
             }
             else if (value == ActionType.Key)
             {
@@ -70,6 +73,16 @@ public partial class ActionEditorViewModel : ObservableObject
             else if (value == ActionType.Open)
             {
                 SelectedAction.Parameter = string.Empty;
+            }
+            else if (value == ActionType.Script)
+            {
+                SelectedAction.Parameter = PieAction.DefaultScriptInterpreter;
+
+                // Default a fresh Script action to hidden, but keep the user's choice when returning to an already-written script.
+                if (string.IsNullOrEmpty(SelectedAction.Script))
+                {
+                    SelectedAction.RunHidden = true;
+                }
             }
 
             OnPropertyChanged();


### PR DESCRIPTION
Resolves #58.

Adds a new **Script** action type: write a multiline PowerShell script directly in the action editor and run it on click, with no separate `.ps1` file:

- The script body is passed to the interpreter via `-NoProfile -ExecutionPolicy Bypass -EncodedCommand <base64>`, where the Base64 is the UTF-16LE bytes of the script. This means multiline bodies, quotes, and newlines need **no escaping and no temp file** (nothing to clean up).
- Runs **hidden by default** (`UseShellExecute=false` + `CreateNoWindow`). A fresh Script action defaults to hidden; once a script is written, the hidden choice is preserved across type toggles.
- **Interpreter** defaults to `powershell.exe` and is editable (e.g. `pwsh.exe` for PowerShell 7).
- Optional working directory. A blank script (`"Script is empty"`) and an over-long script that would exceed the command-line limit (`"Script is too long to run"`) surface clear messages through the existing tray notification path.

This differs from the `Open` type (which shell-executes a target and can't run a script silently): `Script` takes a script you *write* and runs it through PowerShell with a hidden console.

Notes
- Branched off `main` after #67 (the `Shell` → `Open` rename); `Script` is added alongside `Open`.
- Respects the existing invariant that actions never execute during tests, settings load, preview, or validation — only on a slice click.
- `Script` and `RunHidden` are new serialized `PieAction` fields; old settings files load fine (missing values default), and `NormalizeAfterLoad` handles the new `Script` field.

<img width="1308" height="916" alt="image" src="https://github.com/user-attachments/assets/3561ffb0-9288-4054-a77c-472cd24382cb" />
