### PR TITLE
Flick gestures: release the hotkey to trigger the hovered slice

### DIFF
--- a/RadialActions.Tests/Hotkeys/HotkeyUtilTests.cs
+++ b/RadialActions.Tests/Hotkeys/HotkeyUtilTests.cs
@@ -23,6 +23,28 @@ public class HotkeyUtilTests
     }
 
     [Theory]
+    [InlineData(Key.Space, true)]
+    [InlineData(Key.LeftCtrl, true)]
+    [InlineData(Key.RightCtrl, true)]
+    [InlineData(Key.LeftAlt, true)]
+    [InlineData(Key.RightAlt, true)]
+    [InlineData(Key.LeftShift, false)]
+    [InlineData(Key.LWin, false)]
+    [InlineData(Key.A, false)]
+    public void IsHotkeyComponent_CtrlAltSpace_MatchesMainKeyAndModifiers(Key key, bool expected)
+    {
+        var isComponent = HotkeyUtil.IsHotkeyComponent(key, ModifierKeys.Control | ModifierKeys.Alt, Key.Space);
+
+        Assert.Equal(expected, isComponent);
+    }
+
+    [Fact]
+    public void IsHotkeyComponent_NoneKey_NeverMatches()
+    {
+        Assert.False(HotkeyUtil.IsHotkeyComponent(Key.None, ModifierKeys.None, Key.None));
+    }
+
+    [Theory]
     [InlineData(Key.Space, ModifierKeys.Control | ModifierKeys.Alt)]
     [InlineData(Key.F12, ModifierKeys.Shift)]
     [InlineData(Key.D7, ModifierKeys.None)]

--- a/RadialActions.Tests/Settings/SettingsSerializationTests.cs
+++ b/RadialActions.Tests/Settings/SettingsSerializationTests.cs
@@ -133,6 +133,17 @@ public class SettingsSerializationTests
     }
 
     [Fact]
+    public void TriggerSliceOnHotkeyRelease_DefaultsToTrueAndRoundTrips()
+    {
+        var settings = Settings.DeserializeFromJson("{}");
+        Assert.True(settings.TriggerSliceOnHotkeyRelease);
+
+        settings.TriggerSliceOnHotkeyRelease = false;
+        var loaded = Settings.DeserializeFromJson(settings.SerializeToJson());
+        Assert.False(loaded.TriggerSliceOnHotkeyRelease);
+    }
+
+    [Fact]
     public void DeserializeFromJson_MissingIsEnabled_DefaultsToTrue()
     {
         const string json = """

--- a/RadialActions/Hotkeys/HotkeyManager.cs
+++ b/RadialActions/Hotkeys/HotkeyManager.cs
@@ -16,6 +16,11 @@ public class HotkeyManager : IDisposable
     private const uint ModControl = 0x0002;
     private const uint ModShift = 0x0004;
     private const uint ModWin = 0x0008;
+
+    /// <summary>
+    /// Prevents keyboard autorepeat from firing extra WM_HOTKEY messages while the hotkey is held.
+    /// </summary>
+    private const uint ModNoRepeat = 0x4000;
     private int _currentId;
     private readonly Dictionary<string, int> _hotkeys = new(StringComparer.OrdinalIgnoreCase);
     private bool _disposed;
@@ -74,7 +79,7 @@ public class HotkeyManager : IDisposable
 
         var id = ++_currentId;
 
-        if (RegisterHotKey(_windowHandle, id, ToModifierFlags(modifiers), keyCode))
+        if (RegisterHotKey(_windowHandle, id, ToModifierFlags(modifiers) | ModNoRepeat, keyCode))
         {
             _hotkeys[hotkey] = id;
             Log.Information($"Registered hotkey: {hotkey} (ID: {id})");

--- a/RadialActions/Hotkeys/HotkeyUtil.cs
+++ b/RadialActions/Hotkeys/HotkeyUtil.cs
@@ -90,6 +90,24 @@ public static class HotkeyUtil
         return key != Key.None;
     }
 
+    /// <summary>
+    /// Returns whether a key is part of a hotkey combination, either as its main key or as one of its modifiers.
+    /// </summary>
+    public static bool IsHotkeyComponent(Key key, ModifierKeys modifiers, Key hotkeyKey)
+    {
+        if (key == hotkeyKey && key != Key.None)
+            return true;
+
+        return key switch
+        {
+            Key.LeftCtrl or Key.RightCtrl => modifiers.HasFlag(ModifierKeys.Control),
+            Key.LeftAlt or Key.RightAlt => modifiers.HasFlag(ModifierKeys.Alt),
+            Key.LeftShift or Key.RightShift => modifiers.HasFlag(ModifierKeys.Shift),
+            Key.LWin or Key.RWin => modifiers.HasFlag(ModifierKeys.Windows),
+            _ => false
+        };
+    }
+
     public static string BuildHotkeyString(Key key, ModifierKeys modifiers)
     {
         if (key == Key.None)

--- a/RadialActions/MainWindow.xaml
+++ b/RadialActions/MainWindow.xaml
@@ -10,6 +10,7 @@
         d:DataContext="{d:DesignInstance Type=local:MainWindow}"
         AllowsTransparency="True" Background="Transparent"
         Deactivated="Window_Deactivated" PreviewKeyDown="Window_KeyDown"
+        PreviewKeyUp="Window_KeyUp"
         Loaded="Window_Loaded" Opacity="0"
         ResizeMode="NoResize" ShowActivated="False" ShowInTaskbar="False"
         SizeToContent="WidthAndHeight"

--- a/RadialActions/MainWindow.xaml.cs
+++ b/RadialActions/MainWindow.xaml.cs
@@ -21,6 +21,12 @@ public partial class MainWindow : Window
     private readonly HotkeyService _hotkeyService = new();
     private readonly MenuService _menuService;
 
+    /// <summary>
+    /// True while the menu was opened by the activation hotkey and the keys have not been released
+    /// yet, so releasing them over a slice triggers it (flick gesture).
+    /// </summary>
+    private bool _hotkeyReleasePending;
+
     public MainWindow()
     {
         InitializeComponent();
@@ -96,22 +102,25 @@ public partial class MainWindow : Window
 
     public void ShowMenu(bool atCursor)
     {
+        _hotkeyReleasePending = false;
         _menuService.ShowMenu(atCursor);
     }
 
     public void HideMenu(bool animate = true)
     {
+        _hotkeyReleasePending = false;
         _menuService.HideMenu(animate);
     }
 
     private void ShowMenuUsingConfiguredPosition()
     {
+        _hotkeyReleasePending = false;
         _menuService.ShowMenu(!Settings.Default.OpenMenuInScreenCenter);
     }
 
     private async void Window_Loaded(object sender, RoutedEventArgs e)
     {
-        _menuService.HideMenu(animate: false);
+        HideMenu(animate: false);
 
         var handle = new WindowInteropHelper(this).Handle;
         _hotkeyService.Initialize(handle, OnHotkeyPressed);
@@ -137,11 +146,12 @@ public partial class MainWindow : Window
 
         if (IsActive)
         {
-            _menuService.HideMenu();
+            HideMenu();
         }
         else
         {
             ShowMenuUsingConfiguredPosition();
+            _hotkeyReleasePending = Settings.Default.TriggerSliceOnHotkeyRelease;
         }
     }
 
@@ -223,7 +233,7 @@ public partial class MainWindow : Window
 
         if (!Settings.Default.KeepMenuOpenAfterSliceClick)
         {
-            _menuService.HideMenu();
+            HideMenu();
         }
     }
 
@@ -239,7 +249,7 @@ public partial class MainWindow : Window
     private void OnCenterClicked(object sender, EventArgs e)
     {
         Log.Debug("Center close target clicked");
-        _menuService.HideMenu();
+        HideMenu();
     }
 
     private void OnCenterContextMenuRequested(object sender, EventArgs e)
@@ -263,13 +273,13 @@ public partial class MainWindow : Window
         OpenSettingsWindow(1);
         var settingsWindow = Application.Current.Windows.OfType<SettingsWindow>().FirstOrDefault();
         settingsWindow?.SelectAction(e.Slice);
-        _menuService.HideMenu();
+        HideMenu();
     }
 
     private void Window_Deactivated(object sender, EventArgs e)
     {
         Log.Debug("Lost focus");
-        _menuService.HideMenu();
+        HideMenu();
     }
 
     private void Window_KeyDown(object sender, KeyEventArgs e)
@@ -277,7 +287,7 @@ public partial class MainWindow : Window
         if (e.Key == Key.Escape)
         {
             Log.Debug("Escape pressed");
-            _menuService.HideMenu();
+            HideMenu();
             e.Handled = true;
             return;
         }
@@ -294,6 +304,33 @@ public partial class MainWindow : Window
             Log.Debug("Context menu key pressed with no selected slice; opening main context menu");
             OpenMainContextMenu();
             e.Handled = true;
+        }
+    }
+
+    private void Window_KeyUp(object sender, KeyEventArgs e)
+    {
+        if (!_hotkeyReleasePending)
+        {
+            return;
+        }
+
+        var key = e.Key == Key.System ? e.SystemKey : e.Key;
+        if (!HotkeyUtil.TryParse(Settings.Default.ActivationHotkey, out var modifiers, out var hotkeyKey)
+            || !HotkeyUtil.IsHotkeyComponent(key, modifiers, hotkeyKey))
+        {
+            return;
+        }
+
+        _hotkeyReleasePending = false;
+
+        if (PieMenu.TriggerHoveredSlice())
+        {
+            Log.Debug("Activation hotkey released over a slice; triggered it");
+            e.Handled = true;
+        }
+        else
+        {
+            Log.Debug("Activation hotkey released with no slice hovered; menu stays open");
         }
     }
 

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -130,6 +130,27 @@ public partial class PieControl : UserControl
         EnterMouseInteractionMode(refreshVisualState: true, animate: false);
     }
 
+    /// <summary>
+    /// Triggers the slice currently under the mouse, if any.
+    /// </summary>
+    /// <returns>True if a hovered slice was triggered.</returns>
+    public bool TriggerHoveredSlice()
+    {
+        if (_drag != null)
+        {
+            return false;
+        }
+
+        var hoveredSlice = _sliceVisuals.FirstOrDefault(slice => slice.Path.IsMouseOver);
+        if (hoveredSlice == null)
+        {
+            return false;
+        }
+
+        SliceClicked?.Invoke(this, new SliceClickEventArgs(hoveredSlice.Action));
+        return true;
+    }
+
     public bool HandleMenuKey(Key key, ModifierKeys modifiers)
     {
         switch (key)

--- a/RadialActions/Properties/Settings.cs
+++ b/RadialActions/Properties/Settings.cs
@@ -41,6 +41,12 @@ public sealed partial class Settings
     private bool _keepMenuOpenAfterSliceClick;
 
     /// <summary>
+    /// Triggers the hovered slice when the held activation hotkey is released.
+    /// </summary>
+    [ObservableProperty]
+    private bool _triggerSliceOnHotkeyRelease = true;
+
+    /// <summary>
     /// Opens the menu at the center of the current screen instead of the cursor.
     /// </summary>
     [ObservableProperty]

--- a/RadialActions/Settings/GeneralSettingsView.xaml
+++ b/RadialActions/Settings/GeneralSettingsView.xaml
@@ -53,6 +53,31 @@
                         <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <TextBlock Grid.Column="0"
+                               Text="&#xE7C9;"
+                               Style="{StaticResource SettingsCardIconTextBlock}" />
+                    <StackPanel Grid.Column="1"
+                                VerticalAlignment="Center">
+                        <TextBlock Text="Release hotkey to trigger"
+                                   Style="{StaticResource SettingsCardTitleTextBlock}" />
+                        <TextBlock Text="Hold the hotkey, glide onto a slice, and release to run it in one motion."
+                                   Style="{StaticResource SettingsCardDescriptionTextBlock}" />
+                    </StackPanel>
+                    <CheckBox Grid.Column="2"
+                              MinWidth="0"
+                              Margin="16,0,0,0"
+                              VerticalAlignment="Center"
+                              IsChecked="{Binding Settings.TriggerSliceOnHotkeyRelease, Mode=TwoWay}" />
+                </Grid>
+            </Border>
+
+            <Border Style="{StaticResource SettingsCardRowBorder}">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="0"
                                Text="&#xE740;"
                                Style="{StaticResource SettingsCardIconTextBlock}" />
                     <StackPanel Grid.Column="1"


### PR DESCRIPTION
Closes #55

Hold the activation hotkey, glide over a slice, and release to run it in one motion — like Blender-style pie menu flicks. A quick tap naturally falls back to the existing click mode:
- The hotkey is now registered with `MOD_NOREPEAT`, so holding the keys no longer fires repeat `WM_HOTKEY` messages that would toggle the menu closed.
- When the menu opens via the hotkey, the window arms a release-pending flag. Since the menu window takes keyboard focus, the key release arrives as a normal `PreviewKeyUp` — no polling or low-level hook needed.
- Releasing any component of the chord (main key or a modifier, left/right variants included) triggers the hovered slice through the existing `SliceClicked` pipeline, so error notifications and "keep menu open" behave identically to a click.
- Releasing with no slice hovered (e.g. over the center hub after a quick tap) leaves the menu open in click mode.
- Any other show/hide path (tray, Escape, click, focus loss) disarms the flag so a stale release can never fire an action later.
