### PR TITLE
Redesign the Actions editor as a live pie menu

### DIFF
--- a/RadialActions.Tests/Actions/ActionsSettingsViewModelTests.cs
+++ b/RadialActions.Tests/Actions/ActionsSettingsViewModelTests.cs
@@ -18,7 +18,6 @@ public sealed class ActionsSettingsViewModelTests
 
         Assert.Equal(1, settings.SettingsTabIndex);
         Assert.Same(second, viewModel.Actions.SelectedAction);
-        Assert.Equal(1, viewModel.Actions.SelectedActionIndex);
     }
 
     [Fact]
@@ -29,7 +28,6 @@ public sealed class ActionsSettingsViewModelTests
         var viewModel = CreateViewModel(first, second);
 
         Assert.Same(first, viewModel.SelectedAction);
-        Assert.Equal(0, viewModel.SelectedActionIndex);
         Assert.Same(first, viewModel.Editor.SelectedAction);
     }
 
@@ -43,28 +41,53 @@ public sealed class ActionsSettingsViewModelTests
         viewModel.SelectAction(second);
 
         Assert.Same(second, viewModel.SelectedAction);
-        Assert.Equal(1, viewModel.SelectedActionIndex);
         Assert.Same(second, viewModel.Editor.SelectedAction);
     }
 
     [Fact]
-    public void AddAction_InsertsBlankActionAfterSelectedActionAndSelectsIt()
+    public void AddAction_AppendsNewActionAtEndAndSelectsIt()
     {
         var first = PieAction.CreateKeyAction("Mute");
         var second = PieAction.CreateKeyAction("VolumeUp");
-        var third = PieAction.CreateKeyAction("VolumeDown");
-        var viewModel = CreateViewModel(first, second, third);
-        viewModel.SelectAction(second);
+        var viewModel = CreateViewModel(first, second);
+        viewModel.SelectAction(first);
 
         viewModel.AddActionCommand.Execute(null);
 
         var added = viewModel.Actions[2];
-        Assert.Equal([first, second, added, third], viewModel.Actions);
-        Assert.Equal("Blank action", added.Name);
+        Assert.Equal([first, second, added], viewModel.Actions);
+        Assert.Equal(PieAction.DefaultName, added.Name);
         Assert.Equal(ActionType.None, added.Type);
         Assert.Same(added, viewModel.SelectedAction);
-        Assert.Equal(2, viewModel.SelectedActionIndex);
         Assert.Same(added, viewModel.Editor.SelectedAction);
+    }
+
+    [Fact]
+    public void DuplicateAction_InsertsCopyAfterSourceAndSelectsIt()
+    {
+        var first = PieAction.CreateScriptAction("Backup", "Get-Date", icon: "🧹", interpreter: "pwsh.exe", workingDirectory: @"C:\", runHidden: true);
+        first.IsEnabled = false;
+        first.Arguments = "/select";
+        var second = PieAction.CreateKeyAction("Mute");
+        var viewModel = CreateViewModel(first, second);
+        viewModel.SelectAction(first);
+
+        viewModel.DuplicateActionCommand.Execute(null);
+
+        var copy = viewModel.Actions[1];
+        Assert.Equal([first, copy, second], viewModel.Actions);
+        Assert.NotSame(first, copy);
+        Assert.Equal(first.Name, copy.Name);
+        Assert.Equal(first.Icon, copy.Icon);
+        Assert.Equal(first.Type, copy.Type);
+        Assert.Equal(first.IsEnabled, copy.IsEnabled);
+        Assert.Equal(first.Parameter, copy.Parameter);
+        Assert.Equal(first.Arguments, copy.Arguments);
+        Assert.Equal(first.WorkingDirectory, copy.WorkingDirectory);
+        Assert.Equal(first.Script, copy.Script);
+        Assert.Equal(first.RunHidden, copy.RunHidden);
+        Assert.Same(copy, viewModel.SelectedAction);
+        Assert.Same(copy, viewModel.Editor.SelectedAction);
     }
 
     [Fact]
@@ -85,7 +108,6 @@ public sealed class ActionsSettingsViewModelTests
         Assert.Equal("https://a.com", addedA.Parameter);
         Assert.Equal("https://b.com", addedB.Parameter);
         Assert.Same(addedB, viewModel.SelectedAction);
-        Assert.Equal(3, viewModel.SelectedActionIndex);
         Assert.Same(addedB, viewModel.Editor.SelectedAction);
     }
 
@@ -99,7 +121,6 @@ public sealed class ActionsSettingsViewModelTests
         var added = Assert.Single(viewModel.Actions);
         Assert.Equal("https://a.com", added.Parameter);
         Assert.Same(added, viewModel.SelectedAction);
-        Assert.Equal(0, viewModel.SelectedActionIndex);
     }
 
     [Fact]
@@ -113,7 +134,6 @@ public sealed class ActionsSettingsViewModelTests
 
         Assert.Equal([first], viewModel.Actions);
         Assert.Same(first, viewModel.SelectedAction);
-        Assert.Equal(0, viewModel.SelectedActionIndex);
     }
 
     [Fact]
@@ -170,7 +190,6 @@ public sealed class ActionsSettingsViewModelTests
 
         Assert.Equal([first, third], viewModel.Actions);
         Assert.Same(third, viewModel.SelectedAction);
-        Assert.Equal(1, viewModel.SelectedActionIndex);
         Assert.Same(third, viewModel.Editor.SelectedAction);
     }
 
@@ -184,40 +203,7 @@ public sealed class ActionsSettingsViewModelTests
 
         Assert.Empty(viewModel.Actions);
         Assert.Null(viewModel.SelectedAction);
-        Assert.Equal(-1, viewModel.SelectedActionIndex);
         Assert.Null(viewModel.Editor.SelectedAction);
-    }
-
-    [Fact]
-    public void MoveUp_MovesSelectedActionAndKeepsSelection()
-    {
-        var first = PieAction.CreateKeyAction("Mute");
-        var second = PieAction.CreateKeyAction("VolumeUp");
-        var third = PieAction.CreateKeyAction("VolumeDown");
-        var viewModel = CreateViewModel(first, second, third);
-        viewModel.SelectAction(second);
-
-        viewModel.MoveUpCommand.Execute(null);
-
-        Assert.Equal([second, first, third], viewModel.Actions);
-        Assert.Same(second, viewModel.SelectedAction);
-        Assert.Equal(0, viewModel.SelectedActionIndex);
-    }
-
-    [Fact]
-    public void MoveDown_MovesSelectedActionAndKeepsSelection()
-    {
-        var first = PieAction.CreateKeyAction("Mute");
-        var second = PieAction.CreateKeyAction("VolumeUp");
-        var third = PieAction.CreateKeyAction("VolumeDown");
-        var viewModel = CreateViewModel(first, second, third);
-        viewModel.SelectAction(second);
-
-        viewModel.MoveDownCommand.Execute(null);
-
-        Assert.Equal([first, third, second], viewModel.Actions);
-        Assert.Same(second, viewModel.SelectedAction);
-        Assert.Equal(2, viewModel.SelectedActionIndex);
     }
 
     private static ActionsSettingsViewModel CreateViewModel(params PieAction[] actions)

--- a/RadialActions.Tests/Pie/PieReorderCalculatorTests.cs
+++ b/RadialActions.Tests/Pie/PieReorderCalculatorTests.cs
@@ -1,4 +1,4 @@
-using System.Windows;
+﻿using System.Windows;
 
 namespace RadialActions.Tests;
 
@@ -33,6 +33,20 @@ public class PieReorderCalculatorTests
         const int sliceCount = 5;
 
         var slot = PieReorderCalculator.GetTargetSlot(originalIndex, rotationOffset, angleStep, sliceCount);
+
+        Assert.Equal(expectedSlot, slot);
+    }
+
+    [Theory]
+    [InlineData(0, 360, 0)]  // a full lap over the six-slot editor ring (five slices plus the ghost) lands home
+    [InlineData(4, 60, 5)]   // the last slice dragged one slot clockwise lands in the ghost slot, which the control clamps to the last real slot
+    [InlineData(0, -60, 5)]  // the first slice dragged counterclockwise wraps into the ghost slot the same way
+    public void GetTargetSlot_WithEditModeGhostSlot_WrapsOverTheFullSlotRing(int originalIndex, double rotationOffset, int expectedSlot)
+    {
+        const double angleStep = 60;
+        const int slotCount = 6;
+
+        var slot = PieReorderCalculator.GetTargetSlot(originalIndex, rotationOffset, angleStep, slotCount);
 
         Assert.Equal(expectedSlot, slot);
     }

--- a/RadialActions/Actions/Action.cs
+++ b/RadialActions/Actions/Action.cs
@@ -201,6 +201,22 @@ public partial class PieAction : ObservableObject
         };
 
     /// <summary>
+    /// Creates a copy of this action with the same configuration.
+    /// </summary>
+    public PieAction Clone() => new()
+    {
+        Name = Name,
+        Icon = Icon,
+        Type = Type,
+        IsEnabled = IsEnabled,
+        Parameter = Parameter,
+        Arguments = Arguments,
+        WorkingDirectory = WorkingDirectory,
+        Script = Script,
+        RunHidden = RunHidden,
+    };
+
+    /// <summary>
     /// Executes the action.
     /// </summary>
     public void Execute()

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Windows;
+using System.Windows.Automation.Peers;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Input;
@@ -70,6 +71,7 @@ public partial class PieControl : UserControl
     private Point _dragPressPosition;
     private DragReorderState _drag;
     private bool _isReleasingDragCapture;
+    private Path _ghostPath;
 
     private sealed class DragReorderState
     {
@@ -156,6 +158,101 @@ public partial class PieControl : UserControl
 
         SliceClicked?.Invoke(this, new SliceClickEventArgs(hoveredSlice.Action));
         return true;
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        base.OnKeyDown(e);
+
+        if (!IsEditMode || e.Handled)
+        {
+            return;
+        }
+
+        var key = e.Key == Key.System ? e.SystemKey : e.Key;
+        e.Handled = HandleEditModeKey(key, Keyboard.Modifiers);
+    }
+
+    /// <summary>
+    /// Keyboard support for the editor pie: arrows move the selection around the ring, Ctrl+arrows reorder the selected action, Enter or Insert adds one, and Delete removes it.
+    /// </summary>
+    private bool HandleEditModeKey(Key key, ModifierKeys modifiers)
+    {
+        switch (key)
+        {
+            case Key.Right:
+            case Key.Down:
+                return modifiers.HasFlag(ModifierKeys.Control) ? MoveSelectedSlice(1) : MoveEditSelection(1);
+            case Key.Left:
+            case Key.Up:
+                return modifiers.HasFlag(ModifierKeys.Control) ? MoveSelectedSlice(-1) : MoveEditSelection(-1);
+            case Key.Return:
+            case Key.Insert:
+                RequestAddSlice();
+                return true;
+            case Key.Delete:
+                if (SelectedSlice == null)
+                {
+                    return false;
+                }
+
+                RemoveSliceRequested?.Invoke(this, new SliceClickEventArgs(SelectedSlice));
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private bool MoveEditSelection(int delta)
+    {
+        if (_sliceVisuals.Count == 0)
+        {
+            return false;
+        }
+
+        var count = _sliceVisuals.Count;
+        var index = _sliceVisuals.FindIndex(visual => visual.Action == SelectedSlice);
+        index = index < 0
+            ? (delta > 0 ? 0 : count - 1)
+            : (((index + delta) % count) + count) % count;
+        SelectedSlice = _sliceVisuals[index].Action;
+        return true;
+    }
+
+    private bool MoveSelectedSlice(int delta)
+    {
+        if (SelectedSlice == null || Slices == null)
+        {
+            return false;
+        }
+
+        var fromIndex = Slices.IndexOf(SelectedSlice);
+        if (fromIndex < 0 || Slices.Count < 2)
+        {
+            return false;
+        }
+
+        // Wrap like the ring does, so moving past either end carries the slice around.
+        var count = Slices.Count;
+        var toIndex = (((fromIndex + delta) % count) + count) % count;
+        Log.Information("Reordered slice by keyboard: {SliceName} ({FromIndex} -> {ToIndex})", SelectedSlice.Name, fromIndex, toIndex);
+        Slices.Move(fromIndex, toIndex);
+        SlicesReordered?.Invoke(this, EventArgs.Empty);
+        return true;
+    }
+
+    internal void RequestAddSlice()
+    {
+        AddSliceRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    internal IReadOnlyList<PieSliceVisual> SliceVisuals => _sliceVisuals;
+
+    internal Path GhostPath => _ghostPath;
+
+    protected override AutomationPeer OnCreateAutomationPeer()
+    {
+        return new PieControlAutomationPeer(this);
     }
 
     public bool HandleMenuKey(Key key, ModifierKeys modifiers)
@@ -292,10 +389,14 @@ public partial class PieControl : UserControl
 
     private static void OnIsEditModePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is PieControl control)
+        if (d is not PieControl control)
         {
-            control.RequestRenderRefresh();
+            return;
         }
+
+        // The editor is a keyboard-navigable control; the live menu keeps window-level key handling and stays unfocusable.
+        control.Focusable = e.NewValue is true;
+        control.RequestRenderRefresh();
     }
 
     public static readonly DependencyProperty SelectedSliceProperty =
@@ -316,9 +417,18 @@ public partial class PieControl : UserControl
 
     private static void OnSelectedSlicePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
-        if (d is PieControl control)
+        if (d is not PieControl control)
         {
-            control.RefreshVisualState(animate: true);
+            return;
+        }
+
+        control.RefreshVisualState(animate: true);
+
+        if (e.NewValue is PieAction selected
+            && AutomationPeer.ListenerExists(AutomationEvents.SelectionItemPatternOnElementSelected)
+            && UIElementAutomationPeer.FromElement(control) is PieControlAutomationPeer peer)
+        {
+            peer.RaiseSelectionEvent(selected);
         }
     }
 
@@ -408,6 +518,7 @@ public partial class PieControl : UserControl
         _renderRefreshPending = false;
         _drag = null;
         _dragCandidate = null;
+        _ghostPath = null;
 
         // Edit mode shows every action so hidden ones can still be selected and edited; the live menu only shows enabled ones.
         var visibleSlices = Slices?
@@ -581,6 +692,11 @@ public partial class PieControl : UserControl
             slice.MouseLeftButtonDown += (_, e) =>
             {
                 EnterMouseInteractionMode(refreshVisualState: false, animate: false);
+                if (IsEditMode)
+                {
+                    Focus();
+                }
+
                 isMouseDown = true;
                 _animationService.AnimateBrushColor(fillBrush, theme.PressedColor, pressDuration, _renderState.StandardEasing);
                 _animationService.AnimateBrushColor(strokeBrush, _renderState.BorderHoverColor, pressDuration, _renderState.StandardEasing);
@@ -748,6 +864,12 @@ public partial class PieControl : UserControl
 
         _selectionController.EnsureSelectionIsValid(GetSelectionItems());
 
+        // The rendered slices back the automation tree in edit mode, so rebuilds must invalidate the cached child peers.
+        if (IsEditMode && UIElementAutomationPeer.FromElement(this) is PieControlAutomationPeer peer)
+        {
+            peer.ResetChildrenCache();
+        }
+
         Log.Debug(
             "Pie menu rendered with {SliceCount} slices at {CanvasSize}px",
             _sliceVisuals.Count,
@@ -826,6 +948,7 @@ public partial class PieControl : UserControl
 
         ghost.MouseLeftButtonDown += (_, e) =>
         {
+            Focus();
             isMouseDown = true;
             _animationService.AnimateClickDown(ghost, pressDuration, _renderState.StandardEasing);
             e.Handled = true;
@@ -844,6 +967,7 @@ public partial class PieControl : UserControl
             e.Handled = true;
         };
 
+        _ghostPath = ghost;
         Panel.SetZIndex(ghost, SliceZIndex);
         PieCanvas.Children.Add(ghost);
 
@@ -1403,6 +1527,11 @@ public partial class PieControl : UserControl
     /// Occurs when the ghost add slice is clicked in edit mode.
     /// </summary>
     public event EventHandler AddSliceRequested;
+
+    /// <summary>
+    /// Occurs when removal of the selected slice is requested by keyboard in edit mode.
+    /// </summary>
+    public event EventHandler<SliceClickEventArgs> RemoveSliceRequested;
 }
 
 /// <summary>

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -19,6 +19,7 @@ public partial class PieControl : UserControl
 {
     private const double DefaultCenterHoleRatio = 0.25;
     private const int SliceZIndex = 10;
+    private const int SelectedSliceZIndex = 12;
     private const int HoveredSliceZIndex = 14;
     private const int SliceContentZIndex = 15;
     private const int DraggedSliceZIndex = 16;
@@ -63,6 +64,8 @@ public partial class PieControl : UserControl
     private bool _hasKeyboardModeMousePosition;
     private Point _layoutCenter;
     private double _layoutAngleStep;
+    private int _layoutSlotCount;
+    private bool _slicesHandlersAttached;
     private PieSliceVisual _dragCandidate;
     private Point _dragPressPosition;
     private DragReorderState _drag;
@@ -95,6 +98,7 @@ public partial class PieControl : UserControl
     {
         SystemParameters.StaticPropertyChanged += OnSystemParametersChanged;
         SystemEvents.UserPreferenceChanged += OnUserPreferenceChanged;
+        AttachSlicesHandlers();
         RequestRenderRefresh();
     }
 
@@ -102,6 +106,9 @@ public partial class PieControl : UserControl
     {
         SystemParameters.StaticPropertyChanged -= OnSystemParametersChanged;
         SystemEvents.UserPreferenceChanged -= OnUserPreferenceChanged;
+
+        // Detach so a closed or hidden host (like the settings window) doesn't stay alive through handlers on the app-lifetime actions collection.
+        DetachSlicesHandlers(Slices);
     }
 
     private void OnIsVisibleChanged(object sender, DependencyPropertyChangedEventArgs e)
@@ -238,7 +245,7 @@ public partial class PieControl : UserControl
     private bool OpenSelectedSliceContextMenu()
     {
         var selectedSlice = GetSelectedSliceVisual();
-        if (selectedSlice == null)
+        if (selectedSlice?.ContextMenu == null)
         {
             return false;
         }
@@ -267,6 +274,54 @@ public partial class PieControl : UserControl
         set => SetValue(SlicesProperty, value);
     }
 
+    public static readonly DependencyProperty IsEditModeProperty =
+        DependencyProperty.Register(
+            nameof(IsEditMode),
+            typeof(bool),
+            typeof(PieControl),
+            new PropertyMetadata(false, OnIsEditModePropertyChanged));
+
+    /// <summary>
+    /// When true the pie renders as a live editor surface: every action is shown (disabled ones dimmed), a ghost slice at the end adds new actions, clicking selects instead of executing, and the selected slice is highlighted with the accent color.
+    /// </summary>
+    public bool IsEditMode
+    {
+        get => (bool)GetValue(IsEditModeProperty);
+        set => SetValue(IsEditModeProperty, value);
+    }
+
+    private static void OnIsEditModePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is PieControl control)
+        {
+            control.RequestRenderRefresh();
+        }
+    }
+
+    public static readonly DependencyProperty SelectedSliceProperty =
+        DependencyProperty.Register(
+            nameof(SelectedSlice),
+            typeof(PieAction),
+            typeof(PieControl),
+            new FrameworkPropertyMetadata(null, FrameworkPropertyMetadataOptions.BindsTwoWayByDefault, OnSelectedSlicePropertyChanged));
+
+    /// <summary>
+    /// The action highlighted as selected while <see cref="IsEditMode"/> is on.
+    /// </summary>
+    public PieAction SelectedSlice
+    {
+        get => (PieAction)GetValue(SelectedSliceProperty);
+        set => SetValue(SelectedSliceProperty, value);
+    }
+
+    private static void OnSelectedSlicePropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is PieControl control)
+        {
+            control.RefreshVisualState(animate: true);
+        }
+    }
+
     private static void OnSlicesPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         if (d is not PieControl control)
@@ -274,25 +329,47 @@ public partial class PieControl : UserControl
             return;
         }
 
-        if (e.OldValue is ObservableCollection<PieAction> oldCollection)
-        {
-            oldCollection.CollectionChanged -= control.OnSlicesCollectionChanged;
-            foreach (var item in oldCollection)
-            {
-                item.PropertyChanged -= control.OnSlicePropertyChanged;
-            }
-        }
+        control.DetachSlicesHandlers(e.OldValue as ObservableCollection<PieAction>);
 
-        if (e.NewValue is ObservableCollection<PieAction> newCollection)
+        // Wait for Loaded when the binding resolves before the control enters the tree, so unloaded controls never hold handlers on a long-lived collection.
+        if (control.IsLoaded)
         {
-            newCollection.CollectionChanged += control.OnSlicesCollectionChanged;
-            foreach (var item in newCollection)
-            {
-                item.PropertyChanged += control.OnSlicePropertyChanged;
-            }
+            control.AttachSlicesHandlers();
         }
 
         control.RequestRenderRefresh();
+    }
+
+    private void AttachSlicesHandlers()
+    {
+        if (_slicesHandlersAttached || Slices is not ObservableCollection<PieAction> collection)
+        {
+            return;
+        }
+
+        collection.CollectionChanged += OnSlicesCollectionChanged;
+        foreach (var item in collection)
+        {
+            item.PropertyChanged += OnSlicePropertyChanged;
+        }
+
+        _slicesHandlersAttached = true;
+    }
+
+    private void DetachSlicesHandlers(ObservableCollection<PieAction> collection)
+    {
+        if (!_slicesHandlersAttached || collection == null)
+        {
+            return;
+        }
+
+        collection.CollectionChanged -= OnSlicesCollectionChanged;
+        foreach (var item in collection)
+        {
+            item.PropertyChanged -= OnSlicePropertyChanged;
+        }
+
+        _slicesHandlersAttached = false;
     }
 
     private void OnSlicesCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -332,15 +409,19 @@ public partial class PieControl : UserControl
         _drag = null;
         _dragCandidate = null;
 
-        var enabledSlices = Slices?
-            .Where(slice => slice?.IsEnabled == true)
+        // Edit mode shows every action so hidden ones can still be selected and edited; the live menu only shows enabled ones.
+        var visibleSlices = Slices?
+            .Where(slice => slice != null && (IsEditMode || slice.IsEnabled))
             .ToList();
 
-        if (enabledSlices == null || enabledSlices.Count == 0 || ActualWidth <= 0 || ActualHeight <= 0)
+        // The ghost add slice takes up one extra slot in edit mode, so an empty editor still renders a full-circle ghost.
+        var slotCount = (visibleSlices?.Count ?? 0) + (IsEditMode ? 1 : 0);
+
+        if (visibleSlices == null || slotCount == 0 || ActualWidth <= 0 || ActualHeight <= 0)
         {
             Log.Debug(
-                "Skipping pie render (EnabledSlices={EnabledSliceCount}, TotalSlices={TotalSliceCount}, Width={Width}, Height={Height})",
-                enabledSlices?.Count ?? 0,
+                "Skipping pie render (VisibleSlices={VisibleSliceCount}, TotalSlices={TotalSliceCount}, Width={Width}, Height={Height})",
+                visibleSlices?.Count ?? 0,
                 Slices?.Count ?? 0,
                 ActualWidth,
                 ActualHeight);
@@ -356,15 +437,15 @@ public partial class PieControl : UserControl
         if (!PieLayoutCalculator.TryCreateLayout(
                 ActualWidth,
                 ActualHeight,
-                enabledSlices.Count,
+                slotCount,
                 DefaultCenterHoleRatio,
                 theme.SliceStrokeThickness,
                 SnapToDevicePixel,
                 out var layout))
         {
             Log.Warning(
-                "Failed to create pie layout (EnabledSlices={EnabledSliceCount}, TotalSlices={TotalSliceCount}, Width={Width}, Height={Height})",
-                enabledSlices.Count,
+                "Failed to create pie layout (VisibleSlices={VisibleSliceCount}, TotalSlices={TotalSliceCount}, Width={Width}, Height={Height})",
+                visibleSlices.Count,
                 Slices?.Count ?? 0,
                 ActualWidth,
                 ActualHeight);
@@ -394,6 +475,7 @@ public partial class PieControl : UserControl
         var angleStep = layout.AngleStep;
         _layoutCenter = center;
         _layoutAngleStep = angleStep;
+        _layoutSlotCount = slotCount;
 
         if (innerRadius > 0)
         {
@@ -416,73 +498,22 @@ public partial class PieControl : UserControl
             };
             _centerVisual = centerVisual;
 
-            var isCenterMouseDown = false;
-
-            centerElements.Target.MouseEnter += (_, _) =>
+            if (IsEditMode)
             {
-                if (_interactionMode != InteractionMode.Mouse)
+                // The hub is inert in edit mode; there is no menu to close.
+                centerElements.Target.Cursor = Cursors.Arrow;
+                foreach (UIElement child in centerElements.Target.Children)
                 {
-                    return;
-                }
-
-                ApplyCenterHoverVisual(animate: true);
-            };
-
-            centerElements.Target.MouseLeave += (_, _) =>
-            {
-                if (_interactionMode == InteractionMode.Mouse)
-                {
-                    ApplyCenterNormalVisual(animate: true);
-                }
-
-                if (!isCenterMouseDown)
-                {
-                    return;
-                }
-
-                isCenterMouseDown = false;
-                _animationService.AnimateClickUp(centerElements.Target, pressDuration, _renderState.StandardEasing);
-            };
-
-            centerElements.Target.MouseLeftButtonDown += (_, e) =>
-            {
-                EnterMouseInteractionMode(refreshVisualState: false, animate: false);
-                isCenterMouseDown = true;
-                _animationService.AnimateClickDown(centerElements.Target, pressDuration, _renderState.StandardEasing);
-                e.Handled = true;
-            };
-
-            centerElements.Target.MouseLeftButtonUp += (_, e) =>
-            {
-                if (!isCenterMouseDown)
-                {
-                    return;
-                }
-
-                isCenterMouseDown = false;
-                _animationService.AnimateClickUp(centerElements.Target, pressDuration, _renderState.StandardEasing);
-                if (_interactionMode == InteractionMode.Mouse)
-                {
-                    if (centerElements.Target.IsMouseOver)
+                    if (child is FrameworkElement childElement)
                     {
-                        ApplyCenterHoverVisual(animate: true);
-                    }
-                    else
-                    {
-                        ApplyCenterNormalVisual(animate: true);
+                        childElement.Cursor = Cursors.Arrow;
                     }
                 }
-
-                CenterClicked?.Invoke(this, EventArgs.Empty);
-                e.Handled = true;
-            };
-
-            centerElements.Target.MouseRightButtonUp += (_, e) =>
+            }
+            else
             {
-                EnterMouseInteractionMode(refreshVisualState: false, animate: false);
-                CenterContextMenuRequested?.Invoke(this, EventArgs.Empty);
-                e.Handled = true;
-            };
+                WireCenterInteractions(centerElements, pressDuration);
+            }
 
             Canvas.SetLeft(centerElements.Target, SnapToDevicePixel(center.X - innerRadius, isXAxis: true));
             Canvas.SetTop(centerElements.Target, SnapToDevicePixel(center.Y - innerRadius, isXAxis: false));
@@ -490,9 +521,9 @@ public partial class PieControl : UserControl
             PieCanvas.Children.Add(centerElements.Target);
         }
 
-        for (var i = 0; i < enabledSlices.Count; i++)
+        for (var i = 0; i < visibleSlices.Count; i++)
         {
-            var sliceAction = enabledSlices[i];
+            var sliceAction = visibleSlices[i];
             var startAngle = (i * angleStep) - 90;
             var endAngle = startAngle + angleStep;
 
@@ -527,7 +558,8 @@ public partial class PieControl : UserControl
             var reorderRotation = new RotateTransform(0, center.X, center.Y);
             slice.RenderTransform = new TransformGroup { Children = { pressScale, reorderRotation } };
 
-            var contextMenu = CreateSliceContextMenu(sliceAction);
+            // No "Edit..." context menu in edit mode; the slice is already being edited in place.
+            var contextMenu = IsEditMode ? null : CreateSliceContextMenu(sliceAction);
             slice.ContextMenu = contextMenu;
 
             var sliceVisual = new PieSliceVisual
@@ -577,6 +609,12 @@ public partial class PieControl : UserControl
 
                 isMouseDown = false;
                 _animationService.AnimateClickUp(slice, pressDuration, _renderState.StandardEasing);
+
+                if (IsEditMode)
+                {
+                    SelectedSlice = sliceAction;
+                }
+
                 if (_interactionMode == InteractionMode.Mouse)
                 {
                     if (slice.IsMouseOver)
@@ -585,7 +623,7 @@ public partial class PieControl : UserControl
                     }
                     else
                     {
-                        ApplySliceNormalVisual(sliceVisual, animate: true);
+                        ApplySliceRestingVisual(sliceVisual, animate: true);
                     }
                 }
                 else
@@ -616,7 +654,7 @@ public partial class PieControl : UserControl
 
                 if (_interactionMode == InteractionMode.Mouse && _drag == null)
                 {
-                    ApplySliceNormalVisual(sliceVisual, animate: true);
+                    ApplySliceRestingVisual(sliceVisual, animate: true);
                 }
 
                 if (!isMouseDown)
@@ -627,10 +665,17 @@ public partial class PieControl : UserControl
                 isMouseDown = false;
                 _animationService.AnimateClickUp(slice, pressDuration, _renderState.StandardEasing);
             };
+            // Hidden actions render dimmed in edit mode so they can still be selected and edited.
+            if (IsEditMode && !sliceAction.IsEnabled)
+            {
+                slice.Opacity = 0.45;
+            }
+
             Panel.SetZIndex(slice, SliceZIndex);
             PieCanvas.Children.Add(slice);
 
-            if (i < MaxDigitHints)
+            // Digit hints only matter for triggering slices from the live menu.
+            if (!IsEditMode && i < MaxDigitHints)
             {
                 var digitHint = PieVisualBuilder.CreateSliceDigitHint(
                     i + 1,
@@ -687,8 +732,18 @@ public partial class PieControl : UserControl
             sliceVisual.ContentCounter = contentCounter;
             sliceVisual.ContentOrbit = contentOrbit;
 
+            if (IsEditMode && !sliceAction.IsEnabled)
+            {
+                contentPanel.Opacity = 0.45;
+            }
+
             Panel.SetZIndex(contentPanel, SliceContentZIndex);
             PieCanvas.Children.Add(contentPanel);
+        }
+
+        if (IsEditMode)
+        {
+            AddGhostSlice(theme, center, outerRadius, innerRadius, visibleSlices.Count, angleStep);
         }
 
         _selectionController.EnsureSelectionIsValid(GetSelectionItems());
@@ -698,6 +753,190 @@ public partial class PieControl : UserControl
             _sliceVisuals.Count,
             canvasSize);
         RefreshVisualState(animate: false);
+    }
+
+    /// <summary>
+    /// Adds the dashed "+" slice that follows the real slices in edit mode and adds a new action when clicked.
+    /// </summary>
+    private void AddGhostSlice(PieThemeSnapshot theme, Point center, double outerRadius, double innerRadius, int slotIndex, double angleStep)
+    {
+        var startAngle = (slotIndex * angleStep) - 90;
+        var endAngle = startAngle + angleStep;
+
+        // A full-circle arc degenerates (start and end coincide), so an empty editor gets a ring instead of a slice.
+        var ghost = angleStep >= 360
+            ? new Path
+            {
+                Data = new CombinedGeometry(
+                    GeometryCombineMode.Exclude,
+                    new EllipseGeometry(center, outerRadius, outerRadius),
+                    new EllipseGeometry(center, innerRadius, innerRadius)),
+            }
+            : PieLayoutCalculator.CreateSlice(
+                center,
+                outerRadius,
+                innerRadius,
+                startAngle,
+                endAngle,
+                (centerPoint, radius, angle) => PieLayoutCalculator.GetPointOnCircle(centerPoint, radius, angle, SnapPoint));
+        if (theme.SlicePathStyle != null)
+        {
+            ghost.Style = theme.SlicePathStyle;
+        }
+
+        var transparentFill = Color.FromArgb(0, theme.HoverColor.R, theme.HoverColor.G, theme.HoverColor.B);
+        var fillBrush = new SolidColorBrush(transparentFill);
+        var strokeBrush = new SolidColorBrush(theme.BorderColor);
+
+        ghost.Fill = fillBrush;
+        ghost.Stroke = strokeBrush;
+        ghost.StrokeThickness = theme.SliceStrokeThickness;
+        ghost.StrokeDashArray = [4, 3];
+        ghost.Cursor = Cursors.Hand;
+        ghost.SnapsToDevicePixels = true;
+        ghost.ToolTip = "Add an action";
+
+        var pathBounds = ghost.Data.Bounds;
+        ghost.RenderTransform = new ScaleTransform(1, 1)
+        {
+            CenterX = pathBounds.X + (pathBounds.Width / 2),
+            CenterY = pathBounds.Y + (pathBounds.Height / 2),
+        };
+
+        var pressDuration = _renderState.PressDuration;
+        var isMouseDown = false;
+
+        ghost.MouseEnter += (_, _) =>
+        {
+            _animationService.AnimateBrushColor(fillBrush, theme.HoverColor, _renderState.HoverDuration, _renderState.StandardEasing);
+            _animationService.AnimateBrushColor(strokeBrush, theme.AccentColor, _renderState.HoverDuration, _renderState.StandardEasing);
+        };
+
+        ghost.MouseLeave += (_, _) =>
+        {
+            if (isMouseDown)
+            {
+                isMouseDown = false;
+                _animationService.AnimateClickUp(ghost, pressDuration, _renderState.StandardEasing);
+            }
+
+            _animationService.AnimateBrushColor(fillBrush, transparentFill, _renderState.HoverDuration, _renderState.StandardEasing);
+            _animationService.AnimateBrushColor(strokeBrush, theme.BorderColor, _renderState.HoverDuration, _renderState.StandardEasing);
+        };
+
+        ghost.MouseLeftButtonDown += (_, e) =>
+        {
+            isMouseDown = true;
+            _animationService.AnimateClickDown(ghost, pressDuration, _renderState.StandardEasing);
+            e.Handled = true;
+        };
+
+        ghost.MouseLeftButtonUp += (_, e) =>
+        {
+            if (!isMouseDown)
+            {
+                return;
+            }
+
+            isMouseDown = false;
+            _animationService.AnimateClickUp(ghost, pressDuration, _renderState.StandardEasing);
+            AddSliceRequested?.Invoke(this, EventArgs.Empty);
+            e.Handled = true;
+        };
+
+        Panel.SetZIndex(ghost, SliceZIndex);
+        PieCanvas.Children.Add(ghost);
+
+        var textRadius = innerRadius > 0 ? (outerRadius + innerRadius) / 2 : outerRadius * 0.6;
+        var glyphPosition = PieLayoutCalculator.GetTextPosition(center, textRadius, startAngle, endAngle, SnapPoint);
+
+        var addGlyph = new TextBlock
+        {
+            Style = theme.IconTextStyle,
+            Text = "\uE710",
+            FontFamily = new FontFamily("Segoe Fluent Icons, Segoe MDL2 Assets"),
+            Foreground = new SolidColorBrush(theme.AccentColor),
+            FontSize = Math.Max(16, outerRadius * 0.1),
+            IsHitTestVisible = false,
+            SnapsToDevicePixels = true,
+        };
+
+        addGlyph.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+        Canvas.SetLeft(addGlyph, SnapToDevicePixel(glyphPosition.X - (addGlyph.DesiredSize.Width / 2), isXAxis: true));
+        Canvas.SetTop(addGlyph, SnapToDevicePixel(glyphPosition.Y - (addGlyph.DesiredSize.Height / 2), isXAxis: false));
+        Panel.SetZIndex(addGlyph, SliceContentZIndex);
+        PieCanvas.Children.Add(addGlyph);
+    }
+
+    private void WireCenterInteractions(PieVisualBuilder.CenterElements centerElements, Duration pressDuration)
+    {
+        var isCenterMouseDown = false;
+
+        centerElements.Target.MouseEnter += (_, _) =>
+        {
+            if (_interactionMode != InteractionMode.Mouse)
+            {
+                return;
+            }
+
+            ApplyCenterHoverVisual(animate: true);
+        };
+
+        centerElements.Target.MouseLeave += (_, _) =>
+        {
+            if (_interactionMode == InteractionMode.Mouse)
+            {
+                ApplyCenterNormalVisual(animate: true);
+            }
+
+            if (!isCenterMouseDown)
+            {
+                return;
+            }
+
+            isCenterMouseDown = false;
+            _animationService.AnimateClickUp(centerElements.Target, pressDuration, _renderState.StandardEasing);
+        };
+
+        centerElements.Target.MouseLeftButtonDown += (_, e) =>
+        {
+            EnterMouseInteractionMode(refreshVisualState: false, animate: false);
+            isCenterMouseDown = true;
+            _animationService.AnimateClickDown(centerElements.Target, pressDuration, _renderState.StandardEasing);
+            e.Handled = true;
+        };
+
+        centerElements.Target.MouseLeftButtonUp += (_, e) =>
+        {
+            if (!isCenterMouseDown)
+            {
+                return;
+            }
+
+            isCenterMouseDown = false;
+            _animationService.AnimateClickUp(centerElements.Target, pressDuration, _renderState.StandardEasing);
+            if (_interactionMode == InteractionMode.Mouse)
+            {
+                if (centerElements.Target.IsMouseOver)
+                {
+                    ApplyCenterHoverVisual(animate: true);
+                }
+                else
+                {
+                    ApplyCenterNormalVisual(animate: true);
+                }
+            }
+
+            CenterClicked?.Invoke(this, EventArgs.Empty);
+            e.Handled = true;
+        };
+
+        centerElements.Target.MouseRightButtonUp += (_, e) =>
+        {
+            EnterMouseInteractionMode(refreshVisualState: false, animate: false);
+            CenterContextMenuRequested?.Invoke(this, EventArgs.Empty);
+            e.Handled = true;
+        };
     }
 
     private void EnterMouseInteractionMode(bool refreshVisualState, bool animate)
@@ -788,11 +1027,14 @@ public partial class PieControl : UserControl
 
         SetSliceRotation(drag.Slice, drag.RotationOffset);
 
-        var targetSlot = PieReorderCalculator.GetTargetSlot(
-            drag.Slice.Index,
-            drag.RotationOffset,
-            _layoutAngleStep,
-            _sliceVisuals.Count);
+        // Wrap over every layout slot (including the edit-mode ghost) so the angle math matches the geometry, then land ghost-slot drops on the last real slot.
+        var targetSlot = Math.Min(
+            PieReorderCalculator.GetTargetSlot(
+                drag.Slice.Index,
+                drag.RotationOffset,
+                _layoutAngleStep,
+                _layoutSlotCount),
+            _sliceVisuals.Count - 1);
         if (targetSlot == drag.TargetSlot)
         {
             return;
@@ -941,7 +1183,7 @@ public partial class PieControl : UserControl
             }
             else
             {
-                ApplySliceNormalVisual(sliceVisual, animate);
+                ApplySliceRestingVisual(sliceVisual, animate);
             }
         }
 
@@ -950,7 +1192,7 @@ public partial class PieControl : UserControl
             return;
         }
 
-        var isCenterHovered = _interactionMode == InteractionMode.Mouse && _centerVisual.Target.IsMouseOver;
+        var isCenterHovered = !IsEditMode && _interactionMode == InteractionMode.Mouse && _centerVisual.Target.IsMouseOver;
         if (isCenterHovered)
         {
             ApplyCenterHoverVisual(animate);
@@ -961,18 +1203,51 @@ public partial class PieControl : UserControl
         }
     }
 
+    /// <summary>
+    /// Applies the visual a slice returns to when not hovered: the accent selection highlight in edit mode when it is the selected slice, otherwise the normal resting look.
+    /// </summary>
+    private void ApplySliceRestingVisual(PieSliceVisual sliceVisual, bool animate)
+    {
+        if (IsSelectedInEditMode(sliceVisual))
+        {
+            ApplySliceSelectedVisual(sliceVisual, animate);
+        }
+        else
+        {
+            ApplySliceNormalVisual(sliceVisual, animate);
+        }
+    }
+
     private void ApplySliceNormalVisual(PieSliceVisual sliceVisual, bool animate)
     {
         Panel.SetZIndex(sliceVisual.Path, SliceZIndex);
+        sliceVisual.Path.StrokeThickness = _renderState.SliceStrokeThickness;
         _animationService.ApplyBrushColor(sliceVisual.FillBrush, _renderState.SliceColor, animate, _renderState.HoverDuration, _renderState.StandardEasing);
         _animationService.ApplyBrushColor(sliceVisual.StrokeBrush, _renderState.BorderColor, animate, _renderState.HoverDuration, _renderState.StandardEasing);
+    }
+
+    private void ApplySliceSelectedVisual(PieSliceVisual sliceVisual, bool animate)
+    {
+        // Raised above neighbors so the accent stroke is not painted over by their edges.
+        Panel.SetZIndex(sliceVisual.Path, SelectedSliceZIndex);
+        sliceVisual.Path.StrokeThickness = _renderState.SliceStrokeThickness + 1;
+        _animationService.ApplyBrushColor(sliceVisual.FillBrush, _renderState.SelectedFillColor, animate, _renderState.HoverDuration, _renderState.StandardEasing);
+        _animationService.ApplyBrushColor(sliceVisual.StrokeBrush, _renderState.AccentColor, animate, _renderState.HoverDuration, _renderState.StandardEasing);
     }
 
     private void ApplySliceHoverVisual(PieSliceVisual sliceVisual, bool animate)
     {
         Panel.SetZIndex(sliceVisual.Path, HoveredSliceZIndex);
+        sliceVisual.Path.StrokeThickness = IsSelectedInEditMode(sliceVisual)
+            ? _renderState.SliceStrokeThickness + 1
+            : _renderState.SliceStrokeThickness;
         _animationService.ApplyBrushColor(sliceVisual.FillBrush, _renderState.HoverColor, animate, _renderState.HoverDuration, _renderState.StandardEasing);
         _animationService.ApplyBrushColor(sliceVisual.StrokeBrush, _renderState.BorderHoverColor, animate, _renderState.HoverDuration, _renderState.StandardEasing);
+    }
+
+    private bool IsSelectedInEditMode(PieSliceVisual sliceVisual)
+    {
+        return IsEditMode && SelectedSlice != null && sliceVisual.Action == SelectedSlice;
     }
 
     private void ApplyCenterNormalVisual(bool animate)
@@ -1123,6 +1398,11 @@ public partial class PieControl : UserControl
     /// Occurs when the center target requests the main context menu.
     /// </summary>
     public event EventHandler CenterContextMenuRequested;
+
+    /// <summary>
+    /// Occurs when the ghost add slice is clicked in edit mode.
+    /// </summary>
+    public event EventHandler AddSliceRequested;
 }
 
 /// <summary>

--- a/RadialActions/Pie/PieControlAutomationPeer.cs
+++ b/RadialActions/Pie/PieControlAutomationPeer.cs
@@ -1,0 +1,180 @@
+﻿using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Automation.Provider;
+using System.Windows.Shapes;
+using System.Windows.Threading;
+
+namespace RadialActions;
+
+/// <summary>
+/// Exposes the edit-mode pie to UI Automation as a selectable list of actions plus an add button, so screen readers can enumerate and operate the editor. The live menu keeps the default peer behavior.
+/// </summary>
+internal sealed class PieControlAutomationPeer : UserControlAutomationPeer, ISelectionProvider
+{
+    public PieControlAutomationPeer(PieControl owner)
+        : base(owner)
+    {
+    }
+
+    private PieControl Pie => (PieControl)Owner;
+
+    protected override AutomationControlType GetAutomationControlTypeCore()
+    {
+        return Pie.IsEditMode ? AutomationControlType.List : base.GetAutomationControlTypeCore();
+    }
+
+    protected override string GetNameCore()
+    {
+        var name = base.GetNameCore();
+        if (!string.IsNullOrEmpty(name))
+        {
+            return name;
+        }
+
+        return Pie.IsEditMode ? "Actions" : string.Empty;
+    }
+
+    protected override List<AutomationPeer> GetChildrenCore()
+    {
+        if (!Pie.IsEditMode)
+        {
+            return base.GetChildrenCore();
+        }
+
+        var children = new List<AutomationPeer>();
+        foreach (var sliceVisual in Pie.SliceVisuals)
+        {
+            children.Add(new PieSliceAutomationPeer(sliceVisual.Path, Pie, sliceVisual.Action));
+        }
+
+        if (Pie.GhostPath != null)
+        {
+            children.Add(new PieGhostSliceAutomationPeer(Pie.GhostPath, Pie));
+        }
+
+        return children;
+    }
+
+    public override object GetPattern(PatternInterface patternInterface)
+    {
+        if (Pie.IsEditMode && patternInterface == PatternInterface.Selection)
+        {
+            return this;
+        }
+
+        return base.GetPattern(patternInterface);
+    }
+
+    public bool CanSelectMultiple => false;
+
+    public bool IsSelectionRequired => false;
+
+    public IRawElementProviderSimple[] GetSelection()
+    {
+        var selected = Pie.SelectedSlice;
+        if (selected == null)
+        {
+            return [];
+        }
+
+        var peer = GetChildrenCore()?.OfType<PieSliceAutomationPeer>().FirstOrDefault(child => child.Action == selected);
+        return peer == null ? [] : [ProviderFromPeer(peer)];
+    }
+
+    public void RaiseSelectionEvent(PieAction selected)
+    {
+        var peer = GetChildrenCore()?.OfType<PieSliceAutomationPeer>().FirstOrDefault(child => child.Action == selected);
+        peer?.RaiseAutomationEvent(AutomationEvents.SelectionItemPatternOnElementSelected);
+    }
+}
+
+/// <summary>
+/// A single action slice exposed as a selectable list item.
+/// </summary>
+internal sealed class PieSliceAutomationPeer : FrameworkElementAutomationPeer, ISelectionItemProvider
+{
+    private readonly PieControl _pie;
+
+    public PieSliceAutomationPeer(Path owner, PieControl pie, PieAction action)
+        : base(owner)
+    {
+        _pie = pie;
+        Action = action;
+    }
+
+    public PieAction Action { get; }
+
+    protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.ListItem;
+
+    protected override string GetClassNameCore() => nameof(PieSliceAutomationPeer);
+
+    protected override string GetNameCore() => Action.Name ?? string.Empty;
+
+    protected override string GetHelpTextCore() => Action.IsEnabled ? Action.Type.ToString() : $"{Action.Type}, hidden from menu";
+
+    protected override bool IsContentElementCore() => true;
+
+    protected override bool IsControlElementCore() => true;
+
+    public override object GetPattern(PatternInterface patternInterface)
+    {
+        return patternInterface == PatternInterface.SelectionItem ? this : base.GetPattern(patternInterface);
+    }
+
+    public bool IsSelected => _pie.SelectedSlice == Action;
+
+    public IRawElementProviderSimple SelectionContainer
+    {
+        get
+        {
+            var containerPeer = UIElementAutomationPeer.FromElement(_pie);
+            return containerPeer == null ? null : ProviderFromPeer(containerPeer);
+        }
+    }
+
+    public void Select()
+    {
+        _pie.Dispatcher.InvokeAsync(() => _pie.SelectedSlice = Action, DispatcherPriority.Input);
+    }
+
+    public void AddToSelection() => Select();
+
+    public void RemoveFromSelection()
+    {
+        // Single-selection list; deselecting an item is not supported.
+    }
+}
+
+/// <summary>
+/// The ghost add slice exposed as an invokable button.
+/// </summary>
+internal sealed class PieGhostSliceAutomationPeer : FrameworkElementAutomationPeer, IInvokeProvider
+{
+    private readonly PieControl _pie;
+
+    public PieGhostSliceAutomationPeer(Path owner, PieControl pie)
+        : base(owner)
+    {
+        _pie = pie;
+    }
+
+    protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.Button;
+
+    protected override string GetClassNameCore() => nameof(PieGhostSliceAutomationPeer);
+
+    protected override string GetNameCore() => "Add an action";
+
+    protected override bool IsContentElementCore() => true;
+
+    protected override bool IsControlElementCore() => true;
+
+    public override object GetPattern(PatternInterface patternInterface)
+    {
+        return patternInterface == PatternInterface.Invoke ? this : base.GetPattern(patternInterface);
+    }
+
+    public void Invoke()
+    {
+        _pie.Dispatcher.InvokeAsync(_pie.RequestAddSlice, DispatcherPriority.Input);
+    }
+}

--- a/RadialActions/Pie/PieRenderState.cs
+++ b/RadialActions/Pie/PieRenderState.cs
@@ -18,6 +18,9 @@ internal sealed class PieRenderState
     public Color HubHoverColor { get; private set; } = SystemColors.ControlLightColor;
     public Color HubBorderColor { get; private set; } = SystemColors.ControlDarkColor;
     public Color CenterHoverBorderColor { get; private set; } = SystemColors.ControlDarkColor;
+    public Color AccentColor { get; private set; } = SystemColors.HighlightColor;
+    public Color SelectedFillColor { get; private set; } = SystemColors.ControlLightColor;
+    public double SliceStrokeThickness { get; private set; } = 1.5;
 
     public void ApplyTheme(PieThemeSnapshot theme)
     {
@@ -32,5 +35,8 @@ internal sealed class PieRenderState
         HubHoverColor = theme.HubHoverColor;
         HubBorderColor = theme.HubBorderColor;
         CenterHoverBorderColor = theme.CenterHoverBorderColor;
+        AccentColor = theme.AccentColor;
+        SelectedFillColor = theme.SelectedFillColor;
+        SliceStrokeThickness = theme.SliceStrokeThickness;
     }
 }

--- a/RadialActions/Pie/PieThemeSnapshot.cs
+++ b/RadialActions/Pie/PieThemeSnapshot.cs
@@ -36,6 +36,8 @@ internal sealed class PieThemeSnapshot
     public required Color CenterHoverBorderColor { get; init; }
     public required Color IconTextColor { get; init; }
     public required Color LabelTextColor { get; init; }
+    public required Color AccentColor { get; init; }
+    public required Color SelectedFillColor { get; init; }
 
     public static PieThemeSnapshot Capture(
         Func<string, object> tryFindResource,
@@ -161,6 +163,8 @@ internal sealed class PieThemeSnapshot
             labelTextColor = GetAccessibleAccentColor(labelTextColor, sliceColor);
         }
 
+        var selectedFillColor = BlendColor(sliceColor, accentColor, isHighContrast ? 0.5 : 0.18);
+
         return new PieThemeSnapshot
         {
             IsHighContrast = isHighContrast,
@@ -191,6 +195,8 @@ internal sealed class PieThemeSnapshot
             CenterHoverBorderColor = BlendColor(hubBorderColor, accentColor, 0.45),
             IconTextColor = iconTextColor,
             LabelTextColor = labelTextColor,
+            AccentColor = accentColor,
+            SelectedFillColor = selectedFillColor,
         };
     }
 

--- a/RadialActions/Settings/ActionEditorView.xaml
+++ b/RadialActions/Settings/ActionEditorView.xaml
@@ -13,7 +13,7 @@
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </UserControl.Resources>
-    <StackPanel>
+    <StackPanel Margin="0,0,4,0">
         <Grid>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto" />
@@ -27,13 +27,14 @@
 
             <TextBlock Grid.Row="0"
                        Grid.Column="0"
+                       Margin="0,0,0,6"
                        Text="Icon:"
-                       Style="{StaticResource ActionEditorLabelTextBlock}" />
+                       Style="{StaticResource LabelTextBlock}" />
             <TextBox Grid.Row="1"
                      Grid.Column="0"
-                     Width="56"
-                     Height="56"
-                     FontSize="20"
+                     Width="44"
+                     Height="44"
+                     FontSize="18"
                      TextAlignment="Center"
                      VerticalContentAlignment="Center"
                      MaxLength="8"
@@ -42,21 +43,20 @@
 
             <TextBlock Grid.Row="0"
                        Grid.Column="2"
+                       Margin="0,0,0,6"
                        Text="Name:"
-                       Style="{StaticResource ActionEditorLabelTextBlock}" />
+                       Style="{StaticResource LabelTextBlock}" />
             <TextBox Grid.Row="1"
                      Grid.Column="2"
-                     VerticalAlignment="Stretch"
-                     VerticalContentAlignment="Center"
+                     VerticalAlignment="Center"
+                     ToolTip="Shown on the slice as you type; changes are saved automatically"
                      Text="{Binding SelectedAction.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
         </Grid>
-        <TextBlock Text="Shown on the slice as you type. Changes are saved automatically."
-                   Style="{StaticResource DescriptionTextBlock}" />
 
         <CheckBox Content="Show this action in the menu"
+                  Margin="0,14,0,0"
+                  ToolTip="Hidden actions stay dimmed in the editor without losing their configuration"
                   IsChecked="{Binding SelectedAction.IsEnabled, Mode=TwoWay}" />
-        <TextBlock Text="Hidden actions stay dimmed in the editor without losing their configuration."
-                   Style="{StaticResource DescriptionTextBlock}" />
 
         <TextBlock Text="Type:"
                    Style="{StaticResource ActionEditorLabelTextBlock}" />
@@ -76,10 +76,10 @@
                 </DataTemplate>
             </ComboBox.ItemTemplate>
         </ComboBox>
-        <TextBlock Text="Use Key for shortcuts and media controls, Open for apps, files, folders, or URLs, and Script to run PowerShell."
+        <TextBlock Text="Key sends a shortcut or media control, Open launches apps, files, or links, and Script runs PowerShell."
                    Style="{StaticResource DescriptionTextBlock}" />
 
-        <StackPanel Margin="0,0,0,4"
+        <StackPanel
               Visibility="{Binding SelectedActionType, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionType.Key}}">
             <TextBlock Text="Key Action:"
                        Style="{StaticResource ActionEditorLabelTextBlock}" />
@@ -115,7 +115,7 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-            <TextBlock Text="Pick a media, volume, or system command, or record your own shortcut with Custom Shortcut."
+            <TextBlock Text="Pick a command, or record your own with Custom Shortcut."
                        Style="{StaticResource DescriptionTextBlock}" />
 
             <TextBlock Text="Shortcut:"
@@ -124,7 +124,7 @@
             <TextBox Text="{Binding SelectedAction.Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                      Tag="HotkeyInput"
                      Visibility="{Binding SelectedKeyActionId, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionEditorViewModel.CustomKeyActionId}}" />
-            <TextBlock Text="Click the box, then press the key combination to record it, such as Ctrl+Shift+M. Press Backspace to clear."
+            <TextBlock Text="Click the box, then press a combination like Ctrl+Shift+M to record it. Backspace clears."
                        Style="{StaticResource DescriptionTextBlock}"
                        Visibility="{Binding SelectedKeyActionId, Converter={local:MatchToVisibilityConverter}, ConverterParameter={x:Static local:ActionEditorViewModel.CustomKeyActionId}}" />
         </StackPanel>
@@ -146,14 +146,13 @@
                         Command="{Binding BrowseOpenTargetCommand}"
                         Padding="8,2" />
             </Grid>
-            <TextBlock Text="Choose the app, file, folder, URL, or command to open."
+            <TextBlock Text="The app, file, folder, URL, or command to open."
                        Style="{StaticResource DescriptionTextBlock}" />
 
             <TextBlock Text="Arguments:"
                        Style="{StaticResource ActionEditorLabelTextBlock}" />
-            <TextBox Text="{Binding SelectedAction.Arguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            <TextBlock Text="Optional command-line arguments for the target."
-                       Style="{StaticResource DescriptionTextBlock}" />
+            <TextBox ToolTip="Optional command-line arguments for the target"
+                     Text="{Binding SelectedAction.Arguments, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
             <TextBlock Text="Working Directory:"
                        Style="{StaticResource ActionEditorLabelTextBlock}" />
@@ -164,14 +163,13 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
                 <TextBox Grid.Column="0"
+                         ToolTip="Optional folder to use as the target's start location"
                          Text="{Binding SelectedAction.WorkingDirectory, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <Button Grid.Column="2"
                         Content="Browse..."
                         Command="{Binding BrowseWorkingDirectoryCommand}"
                         Padding="8,2" />
             </Grid>
-            <TextBlock Text="Optional folder to use as the target's start location."
-                       Style="{StaticResource DescriptionTextBlock}" />
         </StackPanel>
 
         <StackPanel
@@ -183,19 +181,18 @@
                      AcceptsTab="True"
                      TextWrapping="NoWrap"
                      FontFamily="Consolas, Cascadia Mono, Courier New, monospace"
-                     MinHeight="150"
-                     MaxHeight="320"
+                     MinHeight="140"
+                     MaxHeight="300"
                      VerticalContentAlignment="Top"
                      VerticalScrollBarVisibility="Auto"
                      HorizontalScrollBarVisibility="Auto" />
-            <TextBlock Text="Runs when the slice is clicked. No separate file needed, for example: Get-Date | Out-File $env:TEMP\now.txt"
+            <TextBlock Text="Runs inline when the slice is clicked; no separate file needed."
                        Style="{StaticResource DescriptionTextBlock}" />
 
             <TextBlock Text="Run With:"
                        Style="{StaticResource ActionEditorLabelTextBlock}" />
-            <TextBox Text="{Binding SelectedAction.Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-            <TextBlock Text="The PowerShell to run the script with: powershell.exe (default), or pwsh.exe for PowerShell 7."
-                       Style="{StaticResource DescriptionTextBlock}" />
+            <TextBox ToolTip="powershell.exe (default), or pwsh.exe for PowerShell 7"
+                     Text="{Binding SelectedAction.Parameter, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
             <TextBlock Text="Working Directory:"
                        Style="{StaticResource ActionEditorLabelTextBlock}" />
@@ -206,20 +203,18 @@
                     <ColumnDefinition Width="Auto" />
                 </Grid.ColumnDefinitions>
                 <TextBox Grid.Column="0"
+                         ToolTip="Optional folder to run the script in"
                          Text="{Binding SelectedAction.WorkingDirectory, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
                 <Button Grid.Column="2"
                         Content="Browse..."
                         Command="{Binding BrowseWorkingDirectoryCommand}"
                         Padding="8,2" />
             </Grid>
-            <TextBlock Text="Optional folder to run the script in."
-                       Style="{StaticResource DescriptionTextBlock}" />
 
             <CheckBox Content="Run hidden"
-                      Margin="0,8,0,0"
+                      Margin="0,14,0,0"
+                      ToolTip="Run without showing a console window"
                       IsChecked="{Binding SelectedAction.RunHidden, Mode=TwoWay}" />
-            <TextBlock Text="Run without showing a console window."
-                       Style="{StaticResource DescriptionTextBlock}" />
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/RadialActions/Settings/ActionEditorView.xaml
+++ b/RadialActions/Settings/ActionEditorView.xaml
@@ -14,23 +14,48 @@
         </ResourceDictionary>
     </UserControl.Resources>
     <StackPanel>
-        <TextBlock Text="Enabled:"
-                   Style="{StaticResource ActionEditorLabelTextBlock}" />
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="10" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <TextBlock Grid.Row="0"
+                       Grid.Column="0"
+                       Text="Icon:"
+                       Style="{StaticResource ActionEditorLabelTextBlock}" />
+            <TextBox Grid.Row="1"
+                     Grid.Column="0"
+                     Width="56"
+                     Height="56"
+                     FontSize="20"
+                     TextAlignment="Center"
+                     VerticalContentAlignment="Center"
+                     MaxLength="8"
+                     ToolTip="A short symbol or emoji that fits in a slice"
+                     Text="{Binding SelectedAction.Icon, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+
+            <TextBlock Grid.Row="0"
+                       Grid.Column="2"
+                       Text="Name:"
+                       Style="{StaticResource ActionEditorLabelTextBlock}" />
+            <TextBox Grid.Row="1"
+                     Grid.Column="2"
+                     VerticalAlignment="Stretch"
+                     VerticalContentAlignment="Center"
+                     Text="{Binding SelectedAction.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+        </Grid>
+        <TextBlock Text="Shown on the slice as you type. Changes are saved automatically."
+                   Style="{StaticResource DescriptionTextBlock}" />
+
         <CheckBox Content="Show this action in the menu"
                   IsChecked="{Binding SelectedAction.IsEnabled, Mode=TwoWay}" />
-        <TextBlock Text="Hide this action without removing its configuration."
-                   Style="{StaticResource DescriptionTextBlock}" />
-
-        <TextBlock Text="Name:"
-                   Style="{StaticResource ActionEditorLabelTextBlock}" />
-        <TextBox Text="{Binding SelectedAction.Name, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-        <TextBlock Text="Shown next to the icon in the radial menu."
-                   Style="{StaticResource DescriptionTextBlock}" />
-
-        <TextBlock Text="Icon:"
-                   Style="{StaticResource ActionEditorLabelTextBlock}" />
-        <TextBox Text="{Binding SelectedAction.Icon, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-        <TextBlock Text="Use a short symbol or emoji that fits in a slice."
+        <TextBlock Text="Hidden actions stay dimmed in the editor without losing their configuration."
                    Style="{StaticResource DescriptionTextBlock}" />
 
         <TextBlock Text="Type:"

--- a/RadialActions/Settings/ActionsSettingsView.xaml
+++ b/RadialActions/Settings/ActionsSettingsView.xaml
@@ -19,9 +19,9 @@
             <RowDefinition Height="12" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="1.25*" />
             <ColumnDefinition Width="8" />
-            <ColumnDefinition Width="1.2*" />
+            <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
         <GroupBox Grid.Row="0"
@@ -29,53 +29,51 @@
                   Margin="0"
                   VerticalContentAlignment="Stretch"
                   Style="{StaticResource SettingsCardGroupBox}">
+            <Grid Background="Transparent"
+                  AllowDrop="True"
+                  DragOver="PieStage_DragOver"
+                  Drop="PieStage_Drop">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
+
+                <local:PieControl x:Name="EditorPie"
+                                  Grid.Row="0"
+                                  Margin="8"
+                                  IsEditMode="True"
+                                  Slices="{Binding Actions}"
+                                  SelectedSlice="{Binding SelectedAction, Mode=TwoWay}"
+                                  AddSliceRequested="EditorPie_AddSliceRequested" />
+
+                <TextBlock Grid.Row="1"
+                           Margin="0,10,0,0"
+                           HorizontalAlignment="Center"
+                           TextAlignment="Center"
+                           TextWrapping="Wrap"
+                           FontSize="12"
+                           Opacity="0.72"
+                           Text="Click a slice to edit it, drag it around the ring to reorder, or drop files, apps, and links here to add them." />
+            </Grid>
+        </GroupBox>
+
+        <GroupBox Grid.Row="0"
+                  Grid.Column="2"
+                  Margin="0"
+                  VerticalContentAlignment="Stretch"
+                  Style="{StaticResource SettingsCardGroupBox}"
+                  IsEnabled="{Binding Editor.HasSelectedAction}">
             <Grid>
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
-                <ListBox Grid.Row="0"
-                         AllowDrop="True"
-                         DragOver="ActionsList_DragOver"
-                         Drop="ActionsList_Drop"
-                         ScrollViewer.VerticalScrollBarVisibility="Auto"
-                         ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                         ItemsSource="{Binding Actions}"
-                         SelectedIndex="{Binding SelectedActionIndex}"
-                         SelectedItem="{Binding SelectedAction}">
-                    <ListBox.ItemContainerStyle>
-                        <Style TargetType="ListBoxItem">
-                            <Setter Property="Padding" Value="4,2" />
-                        </Style>
-                    </ListBox.ItemContainerStyle>
-                    <ListBox.ItemTemplate>
-                        <DataTemplate>
-                            <StackPanel Orientation="Horizontal">
-                                <StackPanel.Style>
-                                    <Style TargetType="StackPanel">
-                                        <Style.Triggers>
-                                            <DataTrigger Binding="{Binding IsEnabled}"
-                                                         Value="False">
-                                                <Setter Property="Opacity" Value="0.45" />
-                                            </DataTrigger>
-                                        </Style.Triggers>
-                                    </Style>
-                                </StackPanel.Style>
-                                <TextBlock Text="{Binding Icon}"
-                                           Width="22"
-                                           FontSize="14" />
-                                <TextBlock Text="{Binding Name}"
-                                           Margin="4,0,6,0"
-                                           VerticalAlignment="Center" />
-                                <TextBlock Text="{Binding Type}"
-                                           VerticalAlignment="Center"
-                                           FontSize="10"
-                                           Foreground="Gray" />
-                            </StackPanel>
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
+                <ScrollViewer Grid.Row="0"
+                              VerticalScrollBarVisibility="Auto"
+                              HorizontalScrollBarVisibility="Disabled">
+                    <local:ActionEditorView DataContext="{Binding Editor}" />
+                </ScrollViewer>
 
                 <TextBlock Grid.Row="0"
                            Margin="16"
@@ -85,13 +83,13 @@
                            TextWrapping="Wrap"
                            Foreground="Gray"
                            IsHitTestVisible="False"
-                           Text="Drag files, apps, folders, or links here to add them as actions.">
+                           Text="Click the + slice to add your first action.">
                     <TextBlock.Style>
                         <Style TargetType="TextBlock">
                             <Setter Property="Visibility" Value="Collapsed" />
                             <Style.Triggers>
-                                <DataTrigger Binding="{Binding Actions.Count}"
-                                             Value="0">
+                                <DataTrigger Binding="{Binding Editor.HasSelectedAction}"
+                                             Value="False">
                                     <Setter Property="Visibility" Value="Visible" />
                                 </DataTrigger>
                             </Style.Triggers>
@@ -102,44 +100,24 @@
                 <Grid Grid.Row="1"
                       Margin="0,12,0,0">
                     <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto" />
+                        <ColumnDefinition Width="6" />
+                        <ColumnDefinition Width="Auto" />
                         <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="4" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="4" />
-                        <ColumnDefinition Width="*" />
-                        <ColumnDefinition Width="4" />
-                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
                     </Grid.ColumnDefinitions>
                     <Button Grid.Column="0"
-                            Content="Add"
-                            Command="{Binding AddActionCommand}"
-                            HorizontalAlignment="Stretch" />
+                            Content="Test"
+                            ToolTip="Run this action now to try it out"
+                            Command="{Binding TestActionCommand}" />
                     <Button Grid.Column="2"
-                            Content="Remove"
-                            Command="{Binding RemoveActionCommand}"
-                            HorizontalAlignment="Stretch" />
+                            Content="Duplicate"
+                            Command="{Binding DuplicateActionCommand}" />
                     <Button Grid.Column="4"
-                            Content="Up"
-                            Command="{Binding MoveUpCommand}"
-                            HorizontalAlignment="Stretch" />
-                    <Button Grid.Column="6"
-                            Content="Down"
-                            Command="{Binding MoveDownCommand}"
-                            HorizontalAlignment="Stretch" />
+                            Content="Remove"
+                            Command="{Binding RemoveActionCommand}" />
                 </Grid>
             </Grid>
-        </GroupBox>
-
-        <GroupBox Grid.Row="0"
-                  Grid.Column="2"
-                  Margin="0"
-                  VerticalContentAlignment="Stretch"
-                  Style="{StaticResource SettingsCardGroupBox}"
-                  IsEnabled="{Binding Editor.HasSelectedAction}">
-            <ScrollViewer VerticalScrollBarVisibility="Auto"
-                          HorizontalScrollBarVisibility="Disabled">
-                <local:ActionEditorView DataContext="{Binding Editor}" />
-            </ScrollViewer>
         </GroupBox>
     </Grid>
 </UserControl>

--- a/RadialActions/Settings/ActionsSettingsView.xaml
+++ b/RadialActions/Settings/ActionsSettingsView.xaml
@@ -19,7 +19,7 @@
             <RowDefinition Height="12" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1.25*" />
+            <ColumnDefinition Width="*" />
             <ColumnDefinition Width="8" />
             <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
@@ -55,7 +55,8 @@
                            TextWrapping="Wrap"
                            FontSize="12"
                            Opacity="0.72"
-                           Text="Click a slice or use the arrow keys to pick one. Drag or Ctrl+Arrow reorders, Enter adds, Delete removes, and dropped files, apps, or links become new actions." />
+                           ToolTip="Keyboard: arrow keys select, Ctrl+Arrow reorders, Enter adds, Delete removes"
+                           Text="Click a slice to edit it, drag to reorder, or drop files and links to add them." />
             </Grid>
         </GroupBox>
 

--- a/RadialActions/Settings/ActionsSettingsView.xaml
+++ b/RadialActions/Settings/ActionsSettingsView.xaml
@@ -42,9 +42,11 @@
                                   Grid.Row="0"
                                   Margin="8"
                                   IsEditMode="True"
+                                  AutomationProperties.Name="Actions"
                                   Slices="{Binding Actions}"
                                   SelectedSlice="{Binding SelectedAction, Mode=TwoWay}"
-                                  AddSliceRequested="EditorPie_AddSliceRequested" />
+                                  AddSliceRequested="EditorPie_AddSliceRequested"
+                                  RemoveSliceRequested="EditorPie_RemoveSliceRequested" />
 
                 <TextBlock Grid.Row="1"
                            Margin="0,10,0,0"
@@ -53,7 +55,7 @@
                            TextWrapping="Wrap"
                            FontSize="12"
                            Opacity="0.72"
-                           Text="Click a slice to edit it, drag it around the ring to reorder, or drop files, apps, and links here to add them." />
+                           Text="Click a slice or use the arrow keys to pick one. Drag or Ctrl+Arrow reorders, Enter adds, Delete removes, and dropped files, apps, or links become new actions." />
             </Grid>
         </GroupBox>
 

--- a/RadialActions/Settings/ActionsSettingsView.xaml.cs
+++ b/RadialActions/Settings/ActionsSettingsView.xaml.cs
@@ -15,13 +15,18 @@ public partial class ActionsSettingsView
 
     private ActionsSettingsViewModel ViewModel => DataContext as ActionsSettingsViewModel;
 
-    private void ActionsList_DragOver(object sender, DragEventArgs e)
+    private void EditorPie_AddSliceRequested(object sender, EventArgs e)
+    {
+        ViewModel?.AddActionCommand.Execute(null);
+    }
+
+    private void PieStage_DragOver(object sender, DragEventArgs e)
     {
         e.Effects = GetDropTargets(e.Data).Count > 0 ? DragDropEffects.Copy : DragDropEffects.None;
         e.Handled = true;
     }
 
-    private void ActionsList_Drop(object sender, DragEventArgs e)
+    private void PieStage_Drop(object sender, DragEventArgs e)
     {
         var targets = GetDropTargets(e.Data);
         ResetDragCache();

--- a/RadialActions/Settings/ActionsSettingsView.xaml.cs
+++ b/RadialActions/Settings/ActionsSettingsView.xaml.cs
@@ -20,6 +20,11 @@ public partial class ActionsSettingsView
         ViewModel?.AddActionCommand.Execute(null);
     }
 
+    private void EditorPie_RemoveSliceRequested(object sender, SliceClickEventArgs e)
+    {
+        ViewModel?.RemoveActionCommand.Execute(null);
+    }
+
     private void PieStage_DragOver(object sender, DragEventArgs e)
     {
         e.Effects = GetDropTargets(e.Data).Count > 0 ? DragDropEffects.Copy : DragDropEffects.None;

--- a/RadialActions/Settings/ActionsSettingsViewModel.cs
+++ b/RadialActions/Settings/ActionsSettingsViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.ObjectModel;
+using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using RadialActions.Properties;
@@ -10,9 +11,6 @@ public partial class ActionsSettingsViewModel : ObservableObject
     [ObservableProperty]
     private PieAction _selectedAction;
 
-    [ObservableProperty]
-    private int _selectedActionIndex = -1;
-
     public ActionsSettingsViewModel(Settings settings)
     {
         Settings = settings;
@@ -20,7 +18,6 @@ public partial class ActionsSettingsViewModel : ObservableObject
 
         if (Actions.Count > 0)
         {
-            SelectedActionIndex = 0;
             SelectedAction = Actions[0];
         }
     }
@@ -31,27 +28,18 @@ public partial class ActionsSettingsViewModel : ObservableObject
 
     public void SelectAction(PieAction action)
     {
-        if (action == null)
+        if (action == null || !Actions.Contains(action))
             return;
 
-        var index = Actions.IndexOf(action);
-        if (index < 0)
-            return;
-
-        SelectedActionIndex = index;
         SelectedAction = action;
     }
 
     [RelayCommand]
     private void AddAction()
     {
-        var newAction = new PieAction("Blank action") { Type = ActionType.None };
-
-        var selectedIndex = SelectedAction == null ? -1 : Actions.IndexOf(SelectedAction);
-        var insertionIndex = selectedIndex >= 0 ? selectedIndex + 1 : Actions.Count;
-
-        Actions.Insert(insertionIndex, newAction);
-        SelectedActionIndex = insertionIndex;
+        // The ghost add slice sits at the end of the ring, so the new slice appears where it was clicked.
+        var newAction = new PieAction();
+        Actions.Add(newAction);
         SelectedAction = newAction;
         Log.Debug("Added new action");
     }
@@ -75,56 +63,56 @@ public partial class ActionsSettingsViewModel : ObservableObject
             added++;
         }
 
-        SelectedActionIndex = insertionIndex - 1;
-        SelectedAction = Actions[SelectedActionIndex];
+        SelectedAction = Actions[insertionIndex - 1];
         Log.Debug("Added {Count} action(s) from drop", added);
     }
 
     [RelayCommand]
     private void RemoveAction()
     {
-        if (SelectedAction == null || Actions.Count == 0)
+        if (SelectedAction == null)
             return;
 
         var removed = SelectedAction;
-        var index = SelectedActionIndex;
+        var index = Actions.IndexOf(removed);
         Editor.Forget(removed);
         Actions.Remove(removed);
 
-        if (Actions.Count > 0)
-        {
-            SelectedActionIndex = Math.Min(index, Actions.Count - 1);
-            SelectedAction = Actions[SelectedActionIndex];
-        }
-        else
-        {
-            SelectedAction = null;
-            SelectedActionIndex = -1;
-        }
+        SelectedAction = Actions.Count > 0
+            ? Actions[Math.Min(index, Actions.Count - 1)]
+            : null;
 
         Log.Debug("Removed action");
     }
 
     [RelayCommand]
-    private void MoveUp()
+    private void DuplicateAction()
     {
-        if (SelectedAction == null || SelectedActionIndex <= 0)
+        if (SelectedAction == null)
             return;
 
-        var index = SelectedActionIndex;
-        Actions.Move(index, index - 1);
-        SelectedActionIndex = index - 1;
+        var source = SelectedAction;
+        var copy = source.Clone();
+        Actions.Insert(Actions.IndexOf(source) + 1, copy);
+        SelectedAction = copy;
+        Log.Debug("Duplicated action");
     }
 
     [RelayCommand]
-    private void MoveDown()
+    private void TestAction()
     {
-        if (SelectedAction == null || SelectedActionIndex >= Actions.Count - 1)
+        if (SelectedAction == null)
             return;
 
-        var index = SelectedActionIndex;
-        Actions.Move(index, index + 1);
-        SelectedActionIndex = index + 1;
+        try
+        {
+            SelectedAction.Execute();
+        }
+        catch (Exception ex)
+        {
+            Log.Warning(ex, "Test run failed for action: {ActionName}", SelectedAction.Name);
+            MessageBox.Show(ex.Message, $"Couldn't run \"{SelectedAction.Name}\"", MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
     }
 
     partial void OnSelectedActionChanged(PieAction value)

--- a/RadialActions/Settings/SettingsViewResources.xaml
+++ b/RadialActions/Settings/SettingsViewResources.xaml
@@ -104,7 +104,9 @@
 
     <Style x:Key="ActionEditorLabelTextBlock"
            TargetType="TextBlock"
-           BasedOn="{StaticResource LabelTextBlock}" />
+           BasedOn="{StaticResource LabelTextBlock}">
+        <Setter Property="Margin" Value="0,14,0,6" />
+    </Style>
 
     <Style TargetType="Hyperlink"
            BasedOn="{StaticResource {x:Type Hyperlink}}">


### PR DESCRIPTION
Redesigns the Actions settings tab around a single idea: the editor is the menu. Instead of a ListBox with Add/Remove/Up/Down buttons next to a form, the tab now shows a full-size live pie where you work on the real thing. Fixes #16, since the editor itself is now the always-current preview.

## How it works

- **Click a slice to edit it.** The inspector on the right binds to the selected slice and highlights it on the pie with the system accent color. Edits to name and icon appear on the slice as you type.
- **Drag a slice around the ring to reorder.** Reuses the same drag-reorder machinery as the live menu.
- **Click the dashed "+" ghost slice to add an action.** With no actions at all, the ghost becomes a clickable full ring.
- **Hidden actions stay visible but dimmed** in the editor so they can still be selected and edited.
- **Drop files, apps, folders, or links** anywhere on the pie card to add them as actions, same as before.
- **Full keyboard support:** the pie is focusable; arrow keys move the selection around the ring, Ctrl+Arrow reorders the selected action, Enter or Insert adds one, and Delete removes it.
- **Screen reader support:** a custom automation peer exposes the editor as a list of selectable action items plus an invokable "Add an action" button, with selection events raised as the user moves.
- The inspector gains **Test, Duplicate, and Remove** buttons and an icon + name header. Type-specific fields are unchanged.

## Implementation notes

- `PieControl` gets an `IsEditMode` dependency property that renders all slices (disabled ones dimmed), appends the ghost slice, suppresses digit hints and the hub close target, and turns clicks into selection via a new TwoWay-bindable `SelectedSlice` property. The live menu path is untouched.
- Drag reorder now wraps over the full layout slot ring (including the ghost slot) so a full lap lands home, and drops on the ghost wedge clamp to the last real slot.
- `PieControl` now detaches its `CollectionChanged`/`PropertyChanged` handlers on unload, so the short-lived settings window no longer stays reachable from the app-lifetime actions collection after closing.
- `PieAction.Clone()` backs the Duplicate button so future properties can't be silently dropped from copies.
- `MoveUpCommand`/`MoveDownCommand` and the write-only `SelectedActionIndex` are gone; tests updated and extended (144 passing).

## Verification

Drove the real `SettingsWindow` in an automated harness using genuine mouse and keyboard input (SendInput): click-to-select, live rename, ghost-slice add, Duplicate/Remove buttons, drag reorder (including a full-lap drag and a drop on the ghost wedge), hidden-action dimming, adding the first action from an empty editor, arrow-key selection, Ctrl+Arrow reorder, Enter add, Delete remove, and the UI Automation peer (child enumeration, SelectionItem.Select, and Invoke on the add button). All 26 checks pass, plus the full unit test suite.

## Screenshots

<img width="1186" height="793" alt="image" src="https://github.com/user-attachments/assets/118eb122-1ab0-47dd-92b2-8843003740cc" />
