### PR TITLE
Sync animation frame rate to the refresh rate of the menu's display

### DIFF
--- a/RadialActions/Interop/WpfUtil.cs
+++ b/RadialActions/Interop/WpfUtil.cs
@@ -5,7 +5,7 @@ using System.Windows.Interop;
 namespace RadialActions;
 
 /// <summary>
-/// Utility methods for WPF window positioning.
+/// Utility methods for WPF window positioning and display information.
 /// </summary>
 public static class WpfUtil
 {
@@ -19,8 +19,11 @@ public static class WpfUtil
     [DllImport("user32.dll")]
     private static extern IntPtr MonitorFromPoint(POINT pt, uint dwFlags);
 
-    [DllImport("user32.dll")]
-    private static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFO lpmi);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFOEX lpmi);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern bool EnumDisplaySettings(string lpszDeviceName, int iModeNum, ref DEVMODE lpDevMode);
 
     [DllImport("shcore.dll")]
     private static extern int GetDpiForMonitor(IntPtr hmonitor, MonitorDpiType dpiType, out uint dpiX, out uint dpiY);
@@ -41,13 +44,52 @@ public static class WpfUtil
         public int Bottom;
     }
 
-    [StructLayout(LayoutKind.Sequential)]
-    private struct MONITORINFO
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct MONITORINFOEX
     {
         public int cbSize;
         public RECT rcMonitor;
         public RECT rcWork;
         public uint dwFlags;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string szDevice;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    private struct DEVMODE
+    {
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string dmDeviceName;
+        public ushort dmSpecVersion;
+        public ushort dmDriverVersion;
+        public ushort dmSize;
+        public ushort dmDriverExtra;
+        public uint dmFields;
+        public int dmPositionX;
+        public int dmPositionY;
+        public uint dmDisplayOrientation;
+        public uint dmDisplayFixedOutput;
+        public short dmColor;
+        public short dmDuplex;
+        public short dmYResolution;
+        public short dmTTOption;
+        public short dmCollate;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string dmFormName;
+        public ushort dmLogPixels;
+        public uint dmBitsPerPel;
+        public uint dmPelsWidth;
+        public uint dmPelsHeight;
+        public uint dmDisplayFlags;
+        public uint dmDisplayFrequency;
+        public uint dmICMMethod;
+        public uint dmICMIntent;
+        public uint dmMediaType;
+        public uint dmDitherType;
+        public uint dmReserved1;
+        public uint dmReserved2;
+        public uint dmPanningWidth;
+        public uint dmPanningHeight;
     }
 
     private enum MonitorDpiType
@@ -58,6 +100,7 @@ public static class WpfUtil
     private const uint SWP_NOZORDER = 0x0004;
     private const uint SWP_NOSIZE = 0x0001;
     private const uint MONITOR_DEFAULTTONEAREST = 2;
+    private const int ENUM_CURRENT_SETTINGS = -1;
     private const int DefaultDpi = 96;
 
     /// <summary>
@@ -145,11 +188,32 @@ public static class WpfUtil
         return (int)Math.Round(dipValue * dpiScale);
     }
 
-    private static bool TryGetMonitorInfo(POINT point, out IntPtr monitor, out MONITORINFO monitorInfo)
+    private static bool TryGetMonitorInfo(POINT point, out IntPtr monitor, out MONITORINFOEX monitorInfo)
     {
         monitor = MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST);
-        monitorInfo = new MONITORINFO { cbSize = Marshal.SizeOf<MONITORINFO>() };
+        monitorInfo = new MONITORINFOEX { cbSize = Marshal.SizeOf<MONITORINFOEX>() };
         return monitor != IntPtr.Zero && GetMonitorInfo(monitor, ref monitorInfo);
+    }
+
+    /// <summary>
+    /// Gets the refresh rate in Hz of the display the cursor is currently on, or 0 if it can't be determined.
+    /// </summary>
+    public static int GetCursorMonitorRefreshRate()
+    {
+        if (!GetCursorPos(out var cursorPosition) || !TryGetMonitorInfo(cursorPosition, out _, out var monitorInfo))
+        {
+            return 0;
+        }
+
+        var devMode = new DEVMODE { dmSize = (ushort)Marshal.SizeOf<DEVMODE>() };
+
+        // A frequency of 0 or 1 means the hardware default, not a real rate.
+        if (EnumDisplaySettings(monitorInfo.szDevice, ENUM_CURRENT_SETTINGS, ref devMode) && devMode.dmDisplayFrequency > 1)
+        {
+            return (int)devMode.dmDisplayFrequency;
+        }
+
+        return 0;
     }
 
     private static Size GetWindowSize(Window window)

--- a/RadialActions/Pie/PieAnimationService.cs
+++ b/RadialActions/Pie/PieAnimationService.cs
@@ -1,4 +1,4 @@
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Animation;
 
@@ -6,6 +6,11 @@ namespace RadialActions;
 
 internal sealed class PieAnimationService
 {
+    /// <summary>
+    /// Desired frame rate in Hz for animations, matching the refresh rate of the display the menu is on. Null uses the WPF default of about 60.
+    /// </summary>
+    public int? DesiredFrameRate { get; set; }
+
     public void ApplyBrushColor(
         SolidColorBrush brush,
         Color color,
@@ -43,6 +48,7 @@ internal sealed class PieAnimationService
             EasingFunction = easingFunction,
         };
 
+        Timeline.SetDesiredFrameRate(colorAnimation, DesiredFrameRate);
         brush.BeginAnimation(SolidColorBrush.ColorProperty, colorAnimation, HandoffBehavior.SnapshotAndReplace);
     }
 
@@ -73,6 +79,7 @@ internal sealed class PieAnimationService
             opacityAnimation.Completed += (_, _) => onCompleted();
         }
 
+        Timeline.SetDesiredFrameRate(opacityAnimation, DesiredFrameRate);
         element.BeginAnimation(UIElement.OpacityProperty, opacityAnimation, HandoffBehavior.SnapshotAndReplace);
     }
 
@@ -103,6 +110,7 @@ internal sealed class PieAnimationService
             rotationAnimation.Completed += (_, _) => onCompleted();
         }
 
+        Timeline.SetDesiredFrameRate(rotationAnimation, DesiredFrameRate);
         transform.BeginAnimation(RotateTransform.AngleProperty, rotationAnimation, HandoffBehavior.SnapshotAndReplace);
     }
 
@@ -133,6 +141,7 @@ internal sealed class PieAnimationService
             FillBehavior = FillBehavior.HoldEnd,
         };
 
+        Timeline.SetDesiredFrameRate(scaleAnimation, DesiredFrameRate);
         scaleTransform.BeginAnimation(ScaleTransform.ScaleXProperty, scaleAnimation, HandoffBehavior.SnapshotAndReplace);
         scaleTransform.BeginAnimation(ScaleTransform.ScaleYProperty, scaleAnimation, HandoffBehavior.SnapshotAndReplace);
     }
@@ -161,6 +170,7 @@ internal sealed class PieAnimationService
             EasingFunction = easingFunction,
         };
 
+        Timeline.SetDesiredFrameRate(scaleAnimation, DesiredFrameRate);
         scaleTransform.BeginAnimation(ScaleTransform.ScaleXProperty, scaleAnimation, HandoffBehavior.SnapshotAndReplace);
         scaleTransform.BeginAnimation(ScaleTransform.ScaleYProperty, scaleAnimation, HandoffBehavior.SnapshotAndReplace);
     }

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -76,6 +76,15 @@ public partial class PieControl : UserControl
         public required int TargetSlot { get; set; }
     }
 
+    /// <summary>
+    /// Desired frame rate in Hz for pie animations, matching the refresh rate of the display the menu is on. Null uses the WPF default of about 60.
+    /// </summary>
+    public int? AnimationFrameRate
+    {
+        get => _animationService.DesiredFrameRate;
+        set => _animationService.DesiredFrameRate = value;
+    }
+
     public PieControl()
     {
         InitializeComponent();

--- a/RadialActions/Services/MenuService.cs
+++ b/RadialActions/Services/MenuService.cs
@@ -41,6 +41,8 @@ internal sealed class MenuService
             _window.CenterOnScreen();
         }
 
+        SyncAnimationFrameRate();
+
         if (!_window.IsVisible)
         {
             _window.Opacity = 0;
@@ -52,6 +54,21 @@ internal sealed class MenuService
         _pieMenu.ResetInputState();
         _window.IsHitTestVisible = true;
         BeginFadeIn();
+    }
+
+    /// <summary>
+    /// Points the animation clock at the refresh rate of the display the menu is opening on, so animations aren't capped at the WPF default of about 60 fps.
+    /// Re-queried on every show because the menu can open on a different display each time and rates change with hotplug or settings.
+    /// </summary>
+    private void SyncAnimationFrameRate()
+    {
+        var refreshRate = WpfUtil.GetCursorMonitorRefreshRate();
+        int? desiredFrameRate = refreshRate > 0 ? refreshRate : null;
+        Log.Debug($"Display refresh rate: {refreshRate} Hz");
+
+        Timeline.SetDesiredFrameRate(_fadeInStoryboard, desiredFrameRate);
+        Timeline.SetDesiredFrameRate(_fadeOutStoryboard, desiredFrameRate);
+        _pieMenu.AnimationFrameRate = desiredFrameRate;
     }
 
     public void HideMenu(bool animate = true)


### PR DESCRIPTION
## Summary

WPF ticks its animation timing engine at roughly 60 fps by default regardless of the monitor's refresh rate, so on high refresh rate displays every animation in the app updates only every 2-3 refresh cycles, which reads as judder. This is most visible on the short interactions: hover (83 ms) and press (67 ms) transitions, drag-to-reorder rotation, and the window fades.

Each time the menu is shown, `MenuService` queries the refresh rate of the display the cursor is on (the same display both positioning modes open the menu on) and applies it with `Timeline.SetDesiredFrameRate` to the fade storyboards and, via `PieControl`, to every animation `PieAnimationService` creates.

## Design notes

- **Per-monitor and per-show, not a startup global.** An earlier revision of this PR queried the max rate across all displays once at startup and overrode the `Timeline.DesiredFrameRate` metadata default. That over-ticked slower monitors in mixed-rate setups and could never react to display hotplug, refresh rate changes, or the menu moving between monitors (metadata overrides are one-shot by design). Re-querying on every show costs one native call and handles all of those cases.
- **Minimal native surface.** Reuses the monitor plumbing `WpfUtil` already had for cursor positioning: `MONITORINFO` becomes `MONITORINFOEX` (which carries the device name) and one `EnumDisplaySettings` import plus the `DEVMODE` struct is added. The earlier revision's separate `DisplayUtil` with adapter enumeration is gone.
- Rendering is still vsynced, so the tick rate simply matches what the display can actually present. If the rate can't be determined, the WPF default is used and behavior is unchanged.

## Verification

- Full build and all 142 tests pass, rebased onto current `main` (which now includes #72).
- `GetCursorMonitorRefreshRate` exercised on a dual-monitor setup with the cursor parked on each display in turn, including a secondary monitor at negative coordinates: both resolved to 165 Hz, confirming the device-name lookup works for non-primary displays.
- Live smoke test of the app on a 165 Hz display: the menu renders and fades in with the new frame rate plumbing active, with a clean dismiss and shutdown.