### PR TITLE
Cache the surface ring's drop shadow to cut per-frame GPU cost

### DIFF
--- a/RadialActions/Pie/PieVisualBuilder.cs
+++ b/RadialActions/Pie/PieVisualBuilder.cs
@@ -53,13 +53,23 @@ public static class PieVisualBuilder
             SnapsToDevicePixels = true,
         };
 
+        UIElement surfaceElement = surfacePath;
+
         if (!isHighContrast && ambientShadowEffect != null)
         {
             surfacePath.Effect = ambientShadowEffect.CloneCurrentValue();
+
+            // Wrap in a cached container so the expensive shadow blur is baked into a bitmap once instead of being re-evaluated on every animation frame.
+            surfaceElement = new Border
+            {
+                Child = surfacePath,
+                IsHitTestVisible = false,
+                CacheMode = new BitmapCache(VisualTreeHelper.GetDpi(canvas).PixelsPerDip),
+            };
         }
 
-        Panel.SetZIndex(surfacePath, 0);
-        canvas.Children.Add(surfacePath);
+        Panel.SetZIndex(surfaceElement, 0);
+        canvas.Children.Add(surfaceElement);
     }
 
     public static CenterElements CreateCenterElements(


### PR DESCRIPTION
## Summary

The surface ring carries a `DropShadowEffect` with `BlurRadius=32` and `RenderingBias="Quality"`, and it sits underneath every animating element in the menu. WPF re-evaluates the multi-pass Gaussian blur whenever the scene recomposes, so the blur runs during hover/press transitions, drag-to-reorder, and the window fades, which is exactly when the per-frame budget matters.

This wraps the shadowed ring in a container with a `BitmapCache` (rendered at the current DPI scale so it stays crisp under display scaling), so the blur is rasterized once per menu build and then composited as a texture on every subsequent frame.

## Notes

- `RenderingBias` stays at `Quality`: with the result cached, the high-quality blur only costs once per rebuild instead of once per frame, so there's no reason to trade it away.
- The high-contrast path (which has no shadow) is unchanged.
- Verified with an offscreen render comparison of the old vs. new code path: the shadow gradient matches within 8/255 per channel, and the only larger deltas are sub-pixel antialiasing on the 1px silhouette edge of the ring where the cached bitmap composites. Nothing off-edge changed.