### PR TITLE
Stop rebuilding the pie on every open and build it before the first frame

### DIFF
--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -113,8 +113,8 @@ public partial class PieControl : UserControl
 
         if (!isVisible)
         {
-            Log.Debug("PieControl hidden; deferring render refresh");
-            _renderRefreshPending = true;
+            // Hiding doesn't invalidate anything on its own. Real changes while hidden (theme, slices, size) set the pending flag
+            // themselves through RequestRenderRefresh, whose queued callback returns without clearing it while the menu isn't visible.
             return;
         }
 
@@ -1072,7 +1072,10 @@ public partial class PieControl : UserControl
             }
 
             CreatePieMenu();
-        }, DispatcherPriority.Background);
+
+            // Render priority so the rebuild lands before the next frame is presented. At Background the menu could fade in
+            // while the pie was still missing, making it pop in partway through the animation.
+        }, DispatcherPriority.Render);
     }
 
     private PieSelectionController.Item[] GetSelectionItems()


### PR DESCRIPTION
## Summary

Opening the menu tore down and rebuilt the entire visual tree every time, even when nothing had changed, and that rebuild was queued below render priority so it raced the fade-in. The result was inconsistent open latency: the pie could be on screen before the fade started, or pop in partway through it.

Two changes in `PieControl`:

- **Don't invalidate on hide.** `OnIsVisibleChanged` set `_renderRefreshPending = true` unconditionally every time the menu was hidden, which forced a full rebuild on the next open. Hiding doesn't change anything. Real changes while hidden (theme, slices, size) already flag themselves through `RequestRenderRefresh`, whose queued callback returns *without* clearing the flag while the control isn't visible, so they still rebuild on the next show.
- **Queue the rebuild at `Render` instead of `Background`.** When a rebuild is genuinely needed, it now lands before the next frame is presented rather than whenever the dispatcher happens to drain.

## Measurements

Release build, 165 Hz display. "show->settled" is the time from making the control visible until no rebuild is outstanding and the tree is populated, sampled over 8 open/close cycles:

```
BEFORE
 5 slices | show->settled: median   19.28 ms  min    7.88  max  368.24  rebuilt on 8/8 opens
 8 slices | show->settled: median   34.52 ms  min    8.73  max   96.15  rebuilt on 8/8 opens
12 slices | show->settled: median   50.65 ms  min   10.70  max   52.59  rebuilt on 8/8 opens

AFTER
 5 slices | show->settled: median    1.15 ms  min    0.86  max    2.63  rebuilt on 0/8 opens
 8 slices | show->settled: median    0.99 ms  min    0.78  max    2.56  rebuilt on 0/8 opens
12 slices | show->settled: median    1.76 ms  min    0.87  max    8.38  rebuilt on 0/8 opens
```

The rebuild itself was never expensive (2-6 ms median); the cost was doing it at all on every open, and doing it late. Worst case drops from 368 ms to 8 ms.

## Verification

- Full build and all 142 tests pass.
- Automated correctness check in the profiler: renaming a slice while the menu is hidden still shows the new name after reopening (PASS before and after), covering the case the unconditional invalidation was presumably guarding.
- Rendered the real `PieControl` in a layered window matching `MainWindow`'s composition settings; visually identical to before.