### PR TITLE
Fix six defects found by the pie rendering stack audit

### DIFF
--- a/RadialActions.Tests/Pie/PieSelectionControllerTests.cs
+++ b/RadialActions.Tests/Pie/PieSelectionControllerTests.cs
@@ -13,6 +13,25 @@ public class PieSelectionControllerTests
     ];
 
     [Theory]
+    [InlineData(true, false, 1, 2, PieSelectionController.NoSelection)]
+    [InlineData(true, true, 1, 2, PieSelectionController.NoSelection)]
+    [InlineData(false, true, 1, 2, 1)]
+    [InlineData(false, true, PieSelectionController.NoSelection, 2, PieSelectionController.NoSelection)]
+    [InlineData(false, false, 1, 2, 2)]
+    [InlineData(false, false, PieSelectionController.NoSelection, PieSelectionController.NoSelection, PieSelectionController.NoSelection)]
+    public void GetReleaseTriggerIndex_FollowsInteractionMode(
+        bool isDragActive,
+        bool isKeyboardMode,
+        int selectedIndex,
+        int hoveredIndex,
+        int expectedIndex)
+    {
+        var result = PieSelectionController.GetReleaseTriggerIndex(isDragActive, isKeyboardMode, selectedIndex, hoveredIndex);
+
+        Assert.Equal(expectedIndex, result);
+    }
+
+    [Theory]
     [InlineData(Key.Up, 0)]
     [InlineData(Key.Right, 1)]
     [InlineData(Key.Down, 2)]

--- a/RadialActions/MainWindow.xaml.cs
+++ b/RadialActions/MainWindow.xaml.cs
@@ -221,6 +221,10 @@ public partial class MainWindow : Window
     private void OnSliceClicked(object sender, SliceClickEventArgs e)
     {
         Log.Debug($"Slice clicked: {e.Slice.Name}");
+
+        // A slice has fired; releasing the still-held hotkey must not fire another one when the menu stays open.
+        _hotkeyReleasePending = false;
+
         try
         {
             e.Slice.Execute();

--- a/RadialActions/MainWindow.xaml.cs
+++ b/RadialActions/MainWindow.xaml.cs
@@ -327,7 +327,7 @@ public partial class MainWindow : Window
 
         _hotkeyReleasePending = false;
 
-        if (PieMenu.TriggerHoveredSlice())
+        if (PieMenu.TriggerActiveSlice())
         {
             Log.Debug("Activation hotkey released over a slice; triggered it");
             e.Handled = true;

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -352,6 +352,9 @@ public partial class PieControl : UserControl
                 ActualWidth,
                 ActualHeight);
             _selectionController.Reset();
+
+            // Nothing was rendered; keep the refresh pending so the next opportunity (like the next open) retries.
+            _renderRefreshPending = true;
             return;
         }
 
@@ -375,6 +378,9 @@ public partial class PieControl : UserControl
                 Slices?.Count ?? 0,
                 ActualWidth,
                 ActualHeight);
+
+            // Nothing was rendered; keep the refresh pending so the next opportunity (like the next open) retries.
+            _renderRefreshPending = true;
             return;
         }
 

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -1049,6 +1049,13 @@ public partial class PieControl : UserControl
 
     private void OnSystemParametersChanged(object sender, PropertyChangedEventArgs e)
     {
+        // SystemEvents can deliver on a worker thread, and the refresh path reads dependency properties.
+        if (!Dispatcher.CheckAccess())
+        {
+            Dispatcher.BeginInvoke(() => OnSystemParametersChanged(sender, e));
+            return;
+        }
+
         var propertyName = e.PropertyName;
         if (string.IsNullOrEmpty(propertyName)
             || propertyName.Contains("Color", StringComparison.OrdinalIgnoreCase)
@@ -1062,6 +1069,13 @@ public partial class PieControl : UserControl
 
     private void OnUserPreferenceChanged(object sender, UserPreferenceChangedEventArgs e)
     {
+        // SystemEvents can deliver on a worker thread, and the refresh path reads dependency properties.
+        if (!Dispatcher.CheckAccess())
+        {
+            Dispatcher.BeginInvoke(() => OnUserPreferenceChanged(sender, e));
+            return;
+        }
+
         RequestRenderRefresh();
     }
 

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -870,9 +870,11 @@ public partial class PieControl : UserControl
 
         // Move the dragged action to the position of the action that was built at the target
         // slot; disabled actions keep their relative placement in the collection.
-        var targetAction = _sliceVisuals.First(visual => visual.Index == targetSlot).Action;
+        // The commit runs from an animation callback, so a rebuild (settings edit, theme change) may have
+        // replaced the visuals in the meantime and the target slot may no longer exist.
+        var targetAction = _sliceVisuals.FirstOrDefault(visual => visual.Index == targetSlot)?.Action;
         var fromIndex = Slices.IndexOf(sliceVisual.Action);
-        var toIndex = Slices.IndexOf(targetAction);
+        var toIndex = targetAction == null ? -1 : Slices.IndexOf(targetAction);
         if (fromIndex < 0 || toIndex < 0 || fromIndex == toIndex)
         {
             Log.Warning(

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -127,6 +127,11 @@ public partial class PieControl : UserControl
 
     public void ResetInputState()
     {
+        // The visuals survive across opens, so press and drag tracking from the previous open must be discarded
+        // here or a held button in the next open can resume a drag that was never started there.
+        _drag = null;
+        _dragCandidate = null;
+
         EnterMouseInteractionMode(refreshVisualState: true, animate: false);
     }
 

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -91,6 +91,15 @@ public partial class PieControl : UserControl
         RequestRenderRefresh();
     }
 
+    protected override void OnDpiChanged(DpiScale oldDpi, DpiScale newDpi)
+    {
+        base.OnDpiChanged(oldDpi, newDpi);
+
+        // Snapped geometry and the surface shadow's BitmapCache scale are baked at build-time DPI, and the menu's
+        // size in DIPs doesn't change when it opens on a different-DPI monitor, so nothing else triggers a rebuild.
+        RequestRenderRefresh();
+    }
+
     private void OnLoaded(object sender, RoutedEventArgs e)
     {
         SystemParameters.StaticPropertyChanged += OnSystemParametersChanged;

--- a/RadialActions/Pie/PieControl.xaml.cs
+++ b/RadialActions/Pie/PieControl.xaml.cs
@@ -136,23 +136,25 @@ public partial class PieControl : UserControl
     }
 
     /// <summary>
-    /// Triggers the slice currently under the mouse, if any.
+    /// Triggers the active slice: the keyboard-selected slice in keyboard mode, otherwise the slice under the mouse.
     /// </summary>
-    /// <returns>True if a hovered slice was triggered.</returns>
-    public bool TriggerHoveredSlice()
+    /// <returns>True if a slice was triggered.</returns>
+    public bool TriggerActiveSlice()
     {
-        if (_drag != null)
+        var hoveredIndex = _sliceVisuals.FirstOrDefault(slice => slice.Path.IsMouseOver)?.Index ?? PieSelectionController.NoSelection;
+        var targetIndex = PieSelectionController.GetReleaseTriggerIndex(
+            _drag != null,
+            _interactionMode == InteractionMode.Keyboard,
+            _selectionController.SelectedIndex,
+            hoveredIndex);
+
+        var targetSlice = _sliceVisuals.FirstOrDefault(slice => slice.Index == targetIndex);
+        if (targetSlice == null)
         {
             return false;
         }
 
-        var hoveredSlice = _sliceVisuals.FirstOrDefault(slice => slice.Path.IsMouseOver);
-        if (hoveredSlice == null)
-        {
-            return false;
-        }
-
-        SliceClicked?.Invoke(this, new SliceClickEventArgs(hoveredSlice.Action));
+        SliceClicked?.Invoke(this, new SliceClickEventArgs(targetSlice.Action));
         return true;
     }
 

--- a/RadialActions/Pie/PieSelectionController.cs
+++ b/RadialActions/Pie/PieSelectionController.cs
@@ -15,6 +15,21 @@ internal sealed class PieSelectionController
         SelectedIndex = NoSelection;
     }
 
+    /// <summary>
+    /// Decides which slice a hotkey-release flick should trigger, honoring the active interaction mode
+    /// so the triggered slice always matches the one shown highlighted.
+    /// </summary>
+    /// <returns>The slice index to trigger, or <see cref="NoSelection"/> to trigger nothing.</returns>
+    public static int GetReleaseTriggerIndex(bool isDragActive, bool isKeyboardMode, int selectedIndex, int hoveredIndex)
+    {
+        if (isDragActive)
+        {
+            return NoSelection;
+        }
+
+        return isKeyboardMode ? selectedIndex : hoveredIndex;
+    }
+
     public void EnsureSelectionIsValid(IReadOnlyList<Item> items)
     {
         if (SelectedIndex == NoSelection)


### PR DESCRIPTION
## Summary

An exhaustive audit of the `Pie/*` stack (focused on the interactions between #67-#73) verified 12 defect hypotheses via an instrumented build driven by a UI harness, STA-hosted tests, and code trace. Four confirmed bugs and three latent ones are fixed here, one commit each:

- **Double execution on hotkey release** - with `KeepMenuOpenAfterSliceClick`, clicking a slice while holding the hotkey left the release latch armed, so releasing it executed the slice again (twice total, verified live). The latch now clears when a slice fires.
- **Phantom reorder drag** - since #73 the visuals survive across opens, so a press that ended while the menu was hidden left `_dragCandidate` armed; moving over that slice with the button held in the next open started a drag with no press (verified live). Drag tracking now resets on open.
- **Flick fired the wrong slice in keyboard mode** - releasing the hotkey triggered the mouse-hovered slice even when arrow keys had a different slice highlighted (verified live: selection B highlighted, A executed). The release decision now honors the interaction mode via a pure helper with tests.
- **Reorder commit crash** - a rebuild landing during the 150 ms settle animation (settings edit, theme change) made `CommitReorder` throw `InvalidOperationException` on a stale slot lookup (verified in an STA test). It now falls back to the existing warning path.
- **Blank pie with no retry** - the build clears the refresh-pending flag before its failure early-returns, and #73 removed the hide-time re-arm that used to self-heal it. Failure paths now keep the refresh pending.
- **System events off the UI thread** - `SystemEvents.UserPreferenceChanged` can be raised on a worker thread and the handler reads dependency properties (cross-thread throw verified in an STA test; delivery was on the UI thread in all live probes). Handlers now marshal to the dispatcher.
- **Stale DPI after monitor moves** - pixel snapping and the shadow `BitmapCache` scale are baked at build DPI and nothing re-triggered a rebuild on a DPI change (mechanism code-verified; not runtime-testable on a uniform-DPI machine). `OnDpiChanged` now requests a rebuild.

## Verification

- All fixes re-verified with the same harness protocols that confirmed the bugs: single execution per release, no phantom drag, flick follows keyboard selection, no crash on stale commit, coalescing of hidden refreshes unchanged (10 hidden events -> exactly 1 rebuild on reopen).
- Pixel diff of the rendered pie interior vs `main`: 28 of 121,905 pixels differ within anti-aliasing tolerance (max delta 14) - no visual change.
- `dotnet test`: 148/148 passing, including new cases for the release-trigger decision.

The audit also refuted five suspected defects (stale-hover flick, press-scale leak across opens, shadow-halo clipping from the #72 `BitmapCache`, reduced-motion reorder reentrancy, hidden-refresh coalescing) and found one new issue, filed separately as #74 (clicks fall through during the fade-in).