### PR TITLE
Start the fade-in only after the menu surface has been submitted

### DIFF
--- a/RadialActions/Services/MenuService.cs
+++ b/RadialActions/Services/MenuService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Windows;
 using System.Windows.Input;
+using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
 
@@ -14,6 +15,7 @@ internal sealed class MenuService
     private readonly Dispatcher _dispatcher;
 
     private bool _isFadingOut;
+    private int _fadeInRequestVersion;
 
     public MenuService(
         Window window,
@@ -51,7 +53,44 @@ internal sealed class MenuService
         _ = FocusMenuForKeyboardInputAsync();
         _pieMenu.ResetInputState();
         _window.IsHitTestVisible = true;
-        BeginFadeIn();
+        BeginFadeInWhenSurfaceReady();
+    }
+
+    /// <summary>
+    /// Starts the fade-in only after the layered window has rendered and submitted a frame.
+    /// </summary>
+    /// <remarks>
+    /// The OS hit-tests a layered window against its last submitted surface, and the first submission after
+    /// <see cref="Window.Show"/> lags by several frames. Starting the animation immediately made the fade run
+    /// against a still-invisible, click-through window: the menu appeared mid-animation at high opacity, and
+    /// clicks in that gap fell through to the window beneath, which dismissed the menu via deactivation.
+    /// Waiting two composition ticks (one to render the shown surface, one so it is submitted) keeps the menu
+    /// hittable from the first visible pixel and lets the full fade actually be seen.
+    /// </remarks>
+    private void BeginFadeInWhenSurfaceReady()
+    {
+        var version = ++_fadeInRequestVersion;
+        var renderedTicks = 0;
+
+        void OnRendering(object sender, EventArgs e)
+        {
+            if (version != _fadeInRequestVersion)
+            {
+                CompositionTarget.Rendering -= OnRendering;
+                return;
+            }
+
+            renderedTicks++;
+            if (renderedTicks < 2)
+            {
+                return;
+            }
+
+            CompositionTarget.Rendering -= OnRendering;
+            BeginFadeIn();
+        }
+
+        CompositionTarget.Rendering += OnRendering;
     }
 
     public void HideMenu(bool animate = true)
@@ -122,6 +161,8 @@ internal sealed class MenuService
 
     private void BeginFadeOut()
     {
+        // Cancels any fade-in still waiting on its first rendered frame.
+        _fadeInRequestVersion++;
         StopFadeAnimations();
 
         if (IsReducedMotionEnabled())
@@ -148,6 +189,8 @@ internal sealed class MenuService
 
     private void HideMenuImmediately()
     {
+        // Cancels any fade-in still waiting on its first rendered frame.
+        _fadeInRequestVersion++;
         _isFadingOut = false;
         StopFadeAnimations();
         _window.IsHitTestVisible = false;


### PR DESCRIPTION
Fixes #74.

## Mechanism (measured, not guessed)

The OS hit-tests a layered window against its **last submitted surface**, and the first submission after `Window.Show()` lags by ~120-150 ms on a cold open (~30-60 ms warm). The fade animation started immediately on show, so its clock ran against a window that was still invisible and click-through. Probing `WindowFromPoint` (the same OS path real clicks take) against the fade timeline proved the point:

- With the fade artificially stretched to 4 s, the window became clickable at a **fixed ~150 ms** regardless of opacity (~11% at that moment).
- At the normal 220 ms fade, that same ~150 ms meant the menu appeared mid-animation at ~85-95% opacity (the fade was effectively invisible) and clicks in the gap fell through to the window beneath - which then activated, deactivated the menu, and dismissed it.

## Fix

Defer `BeginFadeIn` by two `CompositionTarget.Rendering` ticks after `ShowMenu`: one tick renders the shown surface, the second guarantees it was submitted. Event-driven, no timers. A version counter cancels a pending fade-in if the menu hides first.

## Measured result (same probe, fixed build)

| Open | Before: visible / hittable | After: visible / hittable |
|------|---------------------------|---------------------------|
| #1 (cold) | +115 ms / +122 ms | +70 ms / **+63 ms** |
| #2 | +54 ms / +50 ms | +54 ms / +46 ms |
| #3 | +58 ms / +32 ms | +50 ms / **+45 ms** |

The menu is now hittable **before** the first visible pixel on every open, and the full 0-to-1 fade actually renders instead of popping in near-full opacity. Clicking a slice the instant it appears executes it (verified 3/3 opens, cold included).

## Verification

- Hit-test/visibility probe as above, plus the full user-level smoke (mouse click, keyboard activation, flick, drag-reorder with settings persistence): all pass.
- `dotnet test`: 148/148.
- Pie interior pixel diff vs `main`: 3 of 121,905 pixels within anti-aliasing tolerance - no visual change to the rendered menu.

Residual (inherent to layered windows): a truly blind click in the first ~50-70 ms - before anything is on screen - still lands beneath the menu; that window shrank from ~150 ms and can't reach zero because a surface cannot be hit-tested before it exists.